### PR TITLE
[PR] Fixed xStarbound support; added global chat and radio

### DIFF
--- a/interface/scripted/starcustomchat/plugins/dynamicprox/dynamicprox.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/dynamicprox.json
@@ -1,21 +1,26 @@
 {
   "name": "Dynamic Prox Chat",
 
-  "modes": [{
-    "name": "Prox",
-    "has_tab": true,
-    "priority": 15,
-    "has_toggle": true
-  }],
+  "modes": [
+    {
+      "name": "Prox",
+      "has_tab": true,
+      "priority": 15,
+      "has_toggle": true
+    }
+  ],
 
   "baseConfigValues": {
     "modeColors": {
-      "Prox" : "CornFlowerBlue"
+      "Prox": "CornFlowerBlue"
     }
   },
 
   "parameters": {
-    "proxRadius": 200
+    "proxRadius": 200,
+    "proxActionRadius": 200,
+    "proxOocRadius": 400,
+    "proxTalkRadius": 50
   },
 
   "script": "/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua"

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/dynamicprox.json.patch.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/dynamicprox.json.patch.lua
@@ -1,0 +1,15 @@
+function patch(config)
+    if xsb then -- Only show the "Proximity (Secondaries)" tick box on xStarbound, the only client it's relevant on.
+        table.insert(
+            config.modes,
+            jobject({
+                name = "ProxSecondary",
+                has_tab = false,
+                priority = 16,
+                has_toggle = true,
+            })
+        )
+        config.baseConfigValues.modeColors.ProxSecondary = config.baseConfigValues.modeColors.Prox
+    end
+    return config
+end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
@@ -7,6 +7,7 @@
   "commands.removetypo.desc": "Removes a typo from your list. {typo}",
   "commands.toggletypos.desc": "Toggles whether or not autocorrection happens",
   "commands.checktypo.desc": "Checks if autocorrection is on or off",
-  "commands.showtypos.desc": "Returns a list of your saved typos and corrections"
+  "commands.showtypos.desc": "Returns a list of your saved typos and corrections",
+  "commands.proxlocal.desc": "Sets whether received local chat will be handled as proximity chat. {on/off}",
+  "commands.sendlocal.desc": "Sets whether chat sent in the Proximity tab will be sent as local chat. {on/off}"
 }
-

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
@@ -1,10 +1,12 @@
 {
-    "chat.modes.Prox": "Dynamic",
-    "settings.plugins.dynamicprox": "Dynamic Proximity Chat",
-    "commands.newlangitem.desc":"Adds a new language item. {name, code, count, automatic, [hex color]}",
-    "commands.addtypo.desc":"Adds a typo to your list. {typo, correction}",
-    "commands.removetypo.desc":"Removes a typo from your list. {typo}",
-    "commands.toggletypos.desc":"Toggles whether or not autocorrection happens",
-    "commands.checktypo.desc":"Checks if autocorrection is on or off",
-    "commands.showtypos.desc":"Returns a list of your saved typos and corrections"
+  "chat.modes.Prox": "Dynamic",
+  "chat.modes.ProxSecondary": "Dynamic (Secondaries)",
+  "settings.plugins.dynamicprox": "Dynamic Proximity Chat",
+  "commands.newlangitem.desc": "Adds a new language item. {name, code, count, automatic, [hex color]}",
+  "commands.addtypo.desc": "Adds a typo to your list. {typo, correction}",
+  "commands.removetypo.desc": "Removes a typo from your list. {typo}",
+  "commands.toggletypos.desc": "Toggles whether or not autocorrection happens",
+  "commands.checktypo.desc": "Checks if autocorrection is on or off",
+  "commands.showtypos.desc": "Returns a list of your saved typos and corrections"
 }
+

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
@@ -8,6 +8,7 @@
   "commands.removetypo.desc": "Removes a typo from your list. {typo}",
   "commands.toggletypos.desc": "Toggles whether or not autocorrection happens",
   "commands.checktypo.desc": "Checks if autocorrection is on or off",
-  "commands.showtypos.desc": "Returns a list of your saved typos and corrections"
+  "commands.showtypos.desc": "Returns a list of your saved typos and corrections",
+  "commands.proxlocal.desc": "Sets whether received local chat will be handled as proximity chat. {on/off}",
+  "commands.sendlocal.desc": "Sets whether chat sent in the Proximity tab will be sent as local chat. {on/off}"
 }
-

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
@@ -1,11 +1,13 @@
 //obviously this isn't russian, someone feel free to translate with a PR
 {
-    "chat.modes.Prox": "Dynamic",
-    "settings.plugins.dynamicprox": "Dynamic Proximity Chat",
-    "commands.newlangitem.desc":"Adds a new language item. {name, code, count, automatic, [hex color]}",
-    "commands.addtypo.desc":"Adds a typo to your list. {typo, correction}",
-    "commands.removetypo.desc":"Removes a typo from your list. {typo}",
-    "commands.toggletypos.desc":"Toggles whether or not autocorrection happens",
-    "commands.checktypo.desc":"Checks if autocorrection is on or off",
-    "commands.showtypos.desc":"Returns a list of your saved typos and corrections"
+  "chat.modes.Prox": "Dynamic",
+  "chat.modes.ProxSecondary": "Dynamic (Secondaries)",
+  "settings.plugins.dynamicprox": "Dynamic Proximity Chat",
+  "commands.newlangitem.desc": "Adds a new language item. {name, code, count, automatic, [hex color]}",
+  "commands.addtypo.desc": "Adds a typo to your list. {typo, correction}",
+  "commands.removetypo.desc": "Removes a typo from your list. {typo}",
+  "commands.toggletypos.desc": "Toggles whether or not autocorrection happens",
+  "commands.checktypo.desc": "Checks if autocorrection is on or off",
+  "commands.showtypos.desc": "Returns a list of your saved typos and corrections"
 }
+

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1018,7 +1018,7 @@ function dynamicprox:formatIncomingMessage(message)
                         local isLower = char == charLower
                         local vowelPattern = mergePattern(vowels)
                         local compFail = randSource:randInt(0, 150)
-                            > (proficiency + wordLength ^ 2 - 2 * wordLength - 10)
+                            > (proficiency - (wordLength ^ 2 + 10) / (math.max(1, proficiency - 50) / 5))
                         if proficiency < 5 or compFail then -- FezzedOne: Added a chance that a word will be partially comprehensible.
                             if charLower:match(vowelPattern) then
                                 local randNum = randSource:randInt(1, #vowels)
@@ -1049,6 +1049,7 @@ function dynamicprox:formatIncomingMessage(message)
                     local byteLC = wordBytes(langCode)
                     local iCount = 1
                     local char
+                    local effProf = 64 * math.log(prof / 3 + 1, 10)
 
                     if langColor == nil then
                         local hexDigits =
@@ -1092,10 +1093,11 @@ function dynamicprox:formatIncomingMessage(message)
                                 randSource:init(tonumber(wordBytes(uniqueId) + byteLC + byteWord))
                                 local wordRoll = randSource:randInt(1, 100)
                                 if
-                                    prof < 5
-                                    or (wordRoll - wordLength + wordLength ^ 2 - 2 * wordLength - 10) > prof
+                                    effProf < 5
+                                    or (wordRoll + (wordLength ^ 2 / (math.max(1, effProf - 50) / 5)) - 10)
+                                        > effProf
                                 then
-                                    wordBuffer = langWordRep(trim(wordBuffer), prof, byteLC)
+                                    wordBuffer = langWordRep(trim(wordBuffer), effProf, byteLC)
                                     wordBuffer = "^" .. langColor .. ";" .. wordBuffer .. "^" .. msgColor .. ";"
                                     rCount = rCount + 1
                                 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1013,7 +1013,7 @@ function dynamicprox:formatIncomingMessage(message)
                     local pickInd = 0
                     local newWord = ""
                     local wordLength = #word
-                    randSource:init(byteLC + wordBytes(word))
+                    randSource:init(math.tointeger(byteLC + wordBytes(word)))
                     for char in word:gmatch(".") do
                         local charLower = char:lower()
                         local isLower = char == charLower
@@ -1063,17 +1063,17 @@ function dynamicprox:formatIncomingMessage(message)
                         local hexMin = 1
 
                         --not sure if there's an cleaner way to do this
-                        randSource:init(byteLC + wordBytes("Red One"))
+                        randSource:init(math.tointeger(byteLC + wordBytes("Red One")))
                         local rNumR = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(byteLC + wordBytes("Green Two"))
+                        randSource:init(math.tointeger(byteLC + wordBytes("Green Two")))
                         local rNumG = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(byteLC + wordBytes("Blue Three"))
+                        randSource:init(math.tointeger(byteLC + wordBytes("Blue Three")))
                         local rNumB = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(byteLC + wordBytes("Red Four"))
+                        randSource:init(math.tointeger(byteLC + wordBytes("Red Four")))
                         local rNumR2 = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(byteLC + wordBytes("Green Five"))
+                        randSource:init(math.tointeger(byteLC + wordBytes("Green Five")))
                         local rNumG2 = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(byteLC + wordBytes("Blue Six"))
+                        randSource:init(math.tointeger(byteLC + wordBytes("Blue Six")))
                         local rNumB2 = hexDigits[randSource:randInt(hexMin, 16)]
                         langColor = "#" .. rNumR .. rNumG .. rNumB .. rNumR2 .. rNumG2 .. rNumB2
                     end
@@ -1092,7 +1092,7 @@ function dynamicprox:formatIncomingMessage(message)
                             if #wordBuffer > 0 then
                                 local wordLength = #wordBuffer
                                 local byteWord = wordBytes(wordBuffer)
-                                randSource:init(uniqueIdBytes + byteLC + byteWord)
+                                randSource:init(math.tointeger(uniqueIdBytes + byteLC + byteWord))
                                 local wordRoll = randSource:randInt(1, 100)
                                 if
                                     effProf < 5

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -217,7 +217,8 @@ function dynamicprox:registerMessageHandlers(shared) --look at this function in 
     end)
 
     starcustomchat.utils.setMessageHandler("/newlangitem", function(_, _, data)
-        local splitArgs = splitStr(data, " ")
+        -- FezzedOne: Whitespace in language names is now supported.
+        local splitArgs = chat.parseArguments(data) -- splitStr(data, " ")
         local langName, langKey, langLevel, isDefault, color =
             (splitArgs[1] or nil),
             (splitArgs[2] or nil),

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -447,6 +447,7 @@ function dynamicprox:onSendMessage(data)
                     end
                     globalMsg:sub(1, -2)
                     globalMsg = "{{" .. globalMsg .. "}}"
+                    globalMsg = globalMsg:gsub("[ ]*", " "):gsub("%{ ", "{"):gsub(" %}", "}")
                     -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
                     chat.send(globalMsg, "Broadcast", false)
                 end
@@ -457,6 +458,7 @@ function dynamicprox:onSendMessage(data)
                     end
                     globalOocMsg:sub(1, -2)
                     globalOocMsg = "((" .. globalOocMsg .. "))"
+                    globalOocMsg = globalOocMsg:gsub("[ ]*", " ")
                     -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
                     chat.send(globalOocMsg, "Broadcast", false)
                 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -563,6 +563,7 @@ end
 function dynamicprox:formatIncomingMessage(rawMessage)
     local messageFormatter = function(message)
         local hasPrefix = message.text:sub(1, #DynamicProxPrefix) == DynamicProxPrefix
+        local isGlobalChat = message.mode == "Broadcast"
         -- FezzedOne: Added a setting that allows local chat to be «funneled» into proximity chat and appropriately formatted and filtered automatically.
         if hasPrefix or (root.getConfiguration("DynamicProxChat::localChatIsProx") and message.mode == "Local") then
             message.mode = "Prox"

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1297,7 +1297,7 @@ function dynamicprox:formatIncomingMessage(message)
                                     end
                                 end
                                 --check message quality
-                                if v["msgQuality"] < 100 and chunkType == "quote" then
+                                if v["msgQuality"] < 100 and not v["isRadio"] and chunkType == "quote" then
                                     chunkStr = degradeMessage(trim(chunkStr), v["msgQuality"])
                                 end
 

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -24,6 +24,8 @@ dynamicprox = PluginClass:new({
 })
 
 local DynamicProxPrefix = "^DynamicProx,reset;"
+local AuthorIdPrefix = "^author="
+local AuthorIdSuffix = ",reset;"
 
 -- FezzedOne: From FezzedTech.
 local function rollDice(die) -- From https://github.com/brianherbert/dice/, with modifications.
@@ -337,1160 +339,1231 @@ function dynamicprox:registerMessageHandlers(shared) --look at this function in 
 end
 
 function dynamicprox:onSendMessage(data)
-    --think about running this in local to allow players without the mod to still see messages
+    local messageSender = function(data)
+        --think about running this in local to allow players without the mod to still see messages
 
-    if data.mode == "Prox" then
-        -- data.time = systemTime() this is where i'd add time if i wanted it
-        data.proxRadius = self.proxRadius
-        local function sendMessageToPlayers()
-            local position = player.id() and world.entityPosition(player.id())
+        if data.mode == "Prox" then
+            -- data.time = systemTime() this is where i'd add time if i wanted it
+            data.proxRadius = self.proxRadius
+            local function sendMessageToPlayers()
+                local position = player.id() and world.entityPosition(player.id())
 
-            -- FezzedOne: Dice roll handling.
-            local rawText = data.text
-            local newStr = ""
-            local cInd = 1
-            while cInd <= #rawText do
-                local c = rawText:sub(cInd, cInd)
-                if c == "\\" then -- Handle escapes.
-                    newStr = newStr .. "\\" .. rawText:sub(cInd + 1, cInd + 1)
-                    cInd = cInd + 1
-                elseif c == "|" then
-                    local fStart = cInd
-                    local fEnd = rawText:find("|", cInd + 1)
-
-                    if fStart ~= nil and fEnd ~= nil then
-                        -- FezzedOne: Replaced dice roller with the more flexible one from FezzedTech.
-                        local diceResults = rawText:sub(fStart + 1, fEnd)
-                        diceResults = diceResults:gsub("[ ]*", ""):gsub(
-                            "(.-)[,|]",
-                            function(die) return tostring(rollDice(die) or "n/a") .. ", " end
-                        )
-                        newStr = newStr .. "|" .. diceResults:sub(1, -3) .. "|"
-                        cInd = fEnd
-                    else
-                        newStr = newStr .. "|"
-                    end
-                else
-                    newStr = newStr .. c
-                end
-                cInd = cInd + 1
-            end
-
-            data.text = newStr
-
-            -- FezzedOne: Global OOC chat.
-            local globalOocStrings = {}
-            data.text = data.text:gsub("\\%(%(%(", "(^;(("):gsub("%(%(%((.-)%)%)%)", function(s)
-                table.insert(globalOocStrings, s)
-                return ""
-            end)
-
-            local globalStrings = {}
-            -- FezzedOne: Global actions and radio. Does not support IC language tags.
-            data.text = data.text:gsub("\\<<", "<^;<"):gsub("\\{{", "{^;{"):gsub("[{<][{<](.-)[}>][}>]", function(s)
-                table.insert(globalStrings, s)
-                return ""
-            end)
-
-            if position then
-                local estRad = data.proxRadius
+                -- FezzedOne: Dice roll handling.
                 local rawText = data.text
-                local sum = 0
-                local parenSum = 0
-                local iCount = 1
-                local globalFlag = false
-                local hasNoise = false
-                local defaultKey = getDefaultLang()
-                data.defaultLang = defaultKey
-                local typoTable = player.getProperty("typos", {})
-                local typoVar = typoTable["typosActive"]
-                if typoVar then
-                    local newText = ""
-                    local wordBuffer = ""
-                    for i in (rawText .. " "):gmatch(".") do
-                        if i:match("[%s%p]") and i ~= "[" and i ~= "]" then
-                            if typoTable[wordBuffer] ~= nil then
-                                newText = newText .. typoTable[wordBuffer] .. i
+                local newStr = ""
+                local cInd = 1
+                while cInd <= #rawText do
+                    local c = rawText:sub(cInd, cInd)
+                    if c == "\\" then -- Handle escapes.
+                        newStr = newStr .. "\\" .. rawText:sub(cInd + 1, cInd + 1)
+                        cInd = cInd + 1
+                    elseif c == "|" then
+                        local fStart = cInd
+                        local fEnd = rawText:find("|", cInd + 1)
 
+                        if fStart ~= nil and fEnd ~= nil then
+                            -- FezzedOne: Replaced dice roller with the more flexible one from FezzedTech.
+                            local diceResults = rawText:sub(fStart + 1, fEnd)
+                            diceResults = diceResults:gsub("[ ]*", ""):gsub(
+                                "(.-)[,|]",
+                                function(die) return tostring(rollDice(die) or "n/a") .. ", " end
+                            )
+                            newStr = newStr .. "|" .. diceResults:sub(1, -3) .. "|"
+                            cInd = fEnd
+                        else
+                            newStr = newStr .. "|"
+                        end
+                    else
+                        newStr = newStr .. c
+                    end
+                    cInd = cInd + 1
+                end
+
+                data.text = newStr
+
+                -- FezzedOne: Global OOC chat.
+                local globalOocStrings = {}
+                data.text = data.text:gsub("\\%(%(%(", "(^;(("):gsub("%(%(%((.-)%)%)%)", function(s)
+                    table.insert(globalOocStrings, s)
+                    return ""
+                end)
+
+                local globalStrings = {}
+                -- FezzedOne: Global actions and radio. Does not support IC language tags.
+                data.text = data.text:gsub("\\<<", "<^;<"):gsub("\\{{", "{^;{"):gsub("[{<][{<](.-)[}>][}>]", function(s)
+                    table.insert(globalStrings, s)
+                    return ""
+                end)
+
+                if position then
+                    local estRad = data.proxRadius
+                    local rawText = data.text
+                    local sum = 0
+                    local parenSum = 0
+                    local iCount = 1
+                    local globalFlag = false
+                    local hasNoise = false
+                    local defaultKey = getDefaultLang()
+                    data.defaultLang = defaultKey
+                    local typoTable = player.getProperty("typos", {})
+                    local typoVar = typoTable["typosActive"]
+                    if typoVar then
+                        local newText = ""
+                        local wordBuffer = ""
+                        for i in (rawText .. " "):gmatch(".") do
+                            if i:match("[%s%p]") and i ~= "[" and i ~= "]" then
+                                if typoTable[wordBuffer] ~= nil then
+                                    newText = newText .. typoTable[wordBuffer] .. i
+
+                                    wordBuffer = ""
+                                else
+                                    newText = newText .. wordBuffer .. i
+                                end
                                 wordBuffer = ""
                             else
-                                newText = newText .. wordBuffer .. i
+                                wordBuffer = wordBuffer .. i
                             end
-                            wordBuffer = ""
-                        else
-                            wordBuffer = wordBuffer .. i
                         end
+                        rawText = newText:sub(1, #newText - 1)
                     end
-                    rawText = newText:sub(1, #newText - 1)
-                end
-                while iCount <= #rawText and not globalFlag do
-                    if parenSum == 3 then globalFlag = true end
+                    while iCount <= #rawText and not globalFlag do
+                        if parenSum == 3 then globalFlag = true end
 
-                    local i = rawText:sub(iCount, iCount)
-                    local langEnd = rawText:find("]", iCount)
-                    -- if langEnd then langEnd = langEnd - 1 end
-                    if i == "\\" then -- FezzedOne: Ignore escaped characters.
-                        iCount = iCount + 1
-                    elseif i == "+" then
-                        sum = sum + 1
-                    elseif i == "(" then
-                        parenSum = parenSum + 1
-                    elseif i == "{" and rawText:find("}", iCount) ~= nil then
-                        globalFlag = true
-                    elseif i == "[" and langEnd ~= nil then --use this flag to check for default languages. A string without any noise won't have any language support
-                        if rawText:sub(iCount + 1, iCount + 1) ~= "[" then -- FezzedOne: If `[[` is detected, don't parse it as a language key.
-                            local langKey
-                            if rawText:sub(iCount, langEnd) == "[]" then --checking for []
-                                langKey = defaultKey
-                                rawText = rawText:gsub("%[%]", "[" .. defaultKey .. "]")
-                            else
-                                -- FezzedOne: Fixed issue where special characters weren't escaped before being passed as a Lua pattern.
-                                langKey = rawText:sub(iCount + 1, langEnd - 1)
-                                langKey = langKey:gsub("[%(%)%.%%%+%-%*%?%[%^%$]", function(s) return "%" .. s end)
-                            end
-                            local upperKey = langKey:upper()
-
-                            local langItem = player.getItemWithParameter("langKey", upperKey)
-
-                            if langItem == nil and upperKey ~= "!!" then
-                                rawText = rawText:gsub("%[" .. langKey, "[" .. defaultKey)
-                            end
-                        else
+                        local i = rawText:sub(iCount, iCount)
+                        local langEnd = rawText:find("]", iCount)
+                        -- if langEnd then langEnd = langEnd - 1 end
+                        if i == "\\" then -- FezzedOne: Ignore escaped characters.
                             iCount = iCount + 1
+                        elseif i == "+" then
+                            sum = sum + 1
+                        elseif i == "(" then
+                            parenSum = parenSum + 1
+                        elseif i == "{" and rawText:find("}", iCount) ~= nil then
+                            globalFlag = true
+                        elseif i == "[" and langEnd ~= nil then --use this flag to check for default languages. A string without any noise won't have any language support
+                            if rawText:sub(iCount + 1, iCount + 1) ~= "[" then -- FezzedOne: If `[[` is detected, don't parse it as a language key.
+                                local langKey
+                                if rawText:sub(iCount, langEnd) == "[]" then --checking for []
+                                    langKey = defaultKey
+                                    rawText = rawText:gsub("%[%]", "[" .. defaultKey .. "]")
+                                else
+                                    -- FezzedOne: Fixed issue where special characters weren't escaped before being passed as a Lua pattern.
+                                    langKey = rawText:sub(iCount + 1, langEnd - 1)
+                                    langKey = langKey:gsub("[%(%)%.%%%+%-%*%?%[%^%$]", function(s) return "%" .. s end)
+                                end
+                                local upperKey = langKey:upper()
+
+                                local langItem = player.getItemWithParameter("langKey", upperKey)
+
+                                if langItem == nil and upperKey ~= "!!" then
+                                    rawText = rawText:gsub("%[" .. langKey, "[" .. defaultKey)
+                                end
+                            else
+                                iCount = iCount + 1
+                            end
+                        else
+                            parenSum = 0
                         end
+                        iCount = iCount + 1
+                    end
+                    data.content = rawText
+                    data.text = ""
+                    if parenSum == 2 or globalFlag then
+                        estRad = estRad * 2
+                    elseif sum > 3 then
+                        estRad = estRad * 1.5
                     else
-                        parenSum = 0
+                        estRad = estRad + (estRad * 0.25 + (3 * sum))
                     end
-                    iCount = iCount + 1
-                end
-                data.content = rawText
-                data.text = ""
-                if parenSum == 2 or globalFlag then
-                    estRad = estRad * 2
-                elseif sum > 3 then
-                    estRad = estRad * 1.5
-                else
-                    estRad = estRad + (estRad * 0.25 + (3 * sum))
-                end
 
-                --estrad should be pretty close to actual radius
+                    --estrad should be pretty close to actual radius
 
-                --this is where i'd change players if needed
-                local players = world.playerQuery(position, estRad, {
-                    boundMode = "position",
-                })
+                    --this is where i'd change players if needed
+                    local players = world.playerQuery(position, estRad, {
+                        boundMode = "position",
+                    })
 
-                -- if xsb then -- FezzedOne: On xStarbound, filter out local secondaries to avoid showing duplicate sent messages.
-                --     local localPlayers = world.ownPlayers()
-                --     local primaryPlayer = world.primaryPlayer()
-                --     for i = #localPlayers, 1, -1 do
-                --         if localPlayers[i] == primaryPlayer then
-                --             table.remove(localPlayers, i)
-                --             break
-                --         end
-                --     end
-                --     for i = #players, 1, -1 do
-                --         for j = 1, #localPlayers, 1 do
-                --             if players[i] == localPlayers[j] then table.remove(players, i) end
-                --         end
-                --     end
-                -- end
+                    -- if xsb then -- FezzedOne: On xStarbound, filter out local secondaries to avoid showing duplicate sent messages.
+                    --     local localPlayers = world.ownPlayers()
+                    --     local primaryPlayer = world.primaryPlayer()
+                    --     for i = #localPlayers, 1, -1 do
+                    --         if localPlayers[i] == primaryPlayer then
+                    --             table.remove(localPlayers, i)
+                    --             break
+                    --         end
+                    --     end
+                    --     for i = #players, 1, -1 do
+                    --         for j = 1, #localPlayers, 1 do
+                    --             if players[i] == localPlayers[j] then table.remove(players, i) end
+                    --         end
+                    --     end
+                    -- end
 
-                -- FezzedOne: Added a setting that allows proximity chat to be sent as local chat for compatibility with «standard» local chat.
-                -- Chat sent this way is prefixed so that it always shows up as proximity chat for those with the mod installed.
-                if root.getConfiguration("DynamicProxChat::sendProxChatInLocal") then
-                    chat.send(DynamicProxPrefix .. data.content, "Local", false)
-                else
-                    for _, pl in ipairs(players) do
-                        if xsb then data.sourceId = world.primaryPlayer() end
-                        data.targetId = pl -- Add the target player ID so we can filter received messages by target player on the other end on xStarbound clients.
-                        world.sendEntityMessage(pl, "scc_add_message", data)
+                    -- FezzedOne: Added a setting that allows proximity chat to be sent as local chat for compatibility with «standard» local chat.
+                    -- Chat sent this way is prefixed so that it always shows up as proximity chat for those with the mod installed.
+                    if root.getConfiguration("DynamicProxChat::sendProxChatInLocal") then
+                        chat.send(
+                            DynamicProxPrefix
+                                .. AuthorIdPrefix
+                                .. tostring(player.id())
+                                .. AuthorIdSuffix
+                                .. data.content,
+                            "Local",
+                            false
+                        )
+                    else
+                        for _, pl in ipairs(players) do
+                            if xsb then data.sourceId = world.primaryPlayer() end
+                            data.targetId = pl -- Add the target player ID so we can filter received messages by target player on the other end on xStarbound clients.
+                            world.sendEntityMessage(pl, "scc_add_message", data)
+                        end
                     end
-                end
-                if #globalStrings ~= 0 then
-                    local globalMsg = ""
-                    for _, str in ipairs(globalStrings) do
-                        globalMsg = globalMsg .. str .. " "
+                    if #globalStrings ~= 0 then
+                        local globalMsg = ""
+                        for _, str in ipairs(globalStrings) do
+                            globalMsg = globalMsg .. str .. " "
+                        end
+                        globalMsg:sub(1, -2)
+                        globalMsg = "{{" .. globalMsg .. "}}"
+                        globalMsg = globalMsg:gsub("[ ]+", " "):gsub("%{ ", "{"):gsub(" %}", "}")
+                        globalMsg = DynamicProxPrefix .. globalMsg
+                        -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
+                        chat.send(globalMsg, "Broadcast", false)
                     end
-                    globalMsg:sub(1, -2)
-                    globalMsg = "{{" .. globalMsg .. "}}"
-                    globalMsg = globalMsg:gsub("[ ]+", " "):gsub("%{ ", "{"):gsub(" %}", "}")
-                    globalMsg = DynamicProxPrefix .. globalMsg
-                    -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
-                    chat.send(globalMsg, "Broadcast", false)
-                end
-                if #globalOocStrings ~= 0 then
-                    local globalOocMsg = ""
-                    for _, str in ipairs(globalOocStrings) do
-                        globalOocMsg = globalOocMsg .. str .. " "
+                    if #globalOocStrings ~= 0 then
+                        local globalOocMsg = ""
+                        for _, str in ipairs(globalOocStrings) do
+                            globalOocMsg = globalOocMsg .. str .. " "
+                        end
+                        globalOocMsg:sub(1, -2)
+                        globalOocMsg = "((" .. globalOocMsg .. "))"
+                        globalOocMsg = globalOocMsg:gsub("[ ]+", " ")
+                        globalOocMsg = DynamicProxPrefix .. globalOocMsg
+                        -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
+                        chat.send(globalOocMsg, "Broadcast", false)
                     end
-                    globalOocMsg:sub(1, -2)
-                    globalOocMsg = "((" .. globalOocMsg .. "))"
-                    globalOocMsg = globalOocMsg:gsub("[ ]+", " ")
-                    globalOocMsg = DynamicProxPrefix .. globalOocMsg
-                    -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
-                    chat.send(globalOocMsg, "Broadcast", false)
+                    return true
                 end
-                return true
             end
+
+            local sendMessagePromise = {
+                finished = sendMessageToPlayers,
+                succeeded = function() return true end,
+            }
+
+            promises:add(sendMessagePromise)
+            player.say("...")
         end
+    end
 
-        local sendMessagePromise = {
-            finished = sendMessageToPlayers,
-            succeeded = function() return true end,
-        }
-
-        promises:add(sendMessagePromise)
-        player.say("...")
+    local status, errorMsg = pcall(messageSender, deepCopy(data))
+    if status then
+        return
+    else
+        sb.logWarn(
+            "[DynamicProxChat] Error occurred while sending proximity message: %s\n  Message data: %s",
+            errorMsg,
+            data
+        )
     end
 end
 
 function dynamicprox:formatIncomingMessage(message)
-    local hasPrefix = message.text:sub(1, #DynamicProxPrefix) == DynamicProxPrefix
-    -- FezzedOne: Added a setting that allows local chat to be «funneled» into proximity chat and appropriately formatted and filtered automatically.
-    if hasPrefix or (root.getConfiguration("DynamicProxChat::localChatIsProx") and message.mode == "Local") then
-        message.mode = "Prox"
-        if hasPrefix and not message.processed then message.text = message.text:sub(#DynamicProxPrefix + 1, -1) end
-        message.contentIsText = true
-    end
-    if message.mode == "Prox" and not message.processed then
-        if not message.contentIsText then message.text = message.content end
-        message.content = ""
+    local messageFormatter = function(message)
+        local hasPrefix = message.text:sub(1, #DynamicProxPrefix) == DynamicProxPrefix
+        -- FezzedOne: Added a setting that allows local chat to be «funneled» into proximity chat and appropriately formatted and filtered automatically.
+        if hasPrefix or (root.getConfiguration("DynamicProxChat::localChatIsProx") and message.mode == "Local") then
+            message.mode = "Prox"
+            if hasPrefix and not message.processed then message.text = message.text:sub(#DynamicProxPrefix + 1, -1) end
+            message.contentIsText = true
+        end
+        if message.mode == "Prox" and not message.processed then
+            if not message.contentIsText then message.text = message.content end
+            message.content = ""
 
-        if message.connection then --i don't know what receivingRestricted does
-            -- FezzedOne: Allows OpenStarbound and StarExtensions clients to correctly display received messages from xStarbound clients.
-            local authorEntityId = message.sourceId or (message.connection * -65536)
-            local receiverEntityId = message.targetId or player.id()
-            local ownPlayers = world.ownPlayers()
-            local isLocalPlayer = function(entityId)
-                if not xsb then return true end
-                for _, plr in ipairs(ownPlayers) do
-                    if entityId == plr then return true end
+            if message.connection then --i don't know what receivingRestricted does
+                local hasAuthorPrefix = message.text:sub(1, #AuthorIdPrefix) == AuthorIdPrefix
+                local authorEntityId
+                if hasAuthorPrefix then
+                    local i = #AuthorIdPrefix + 1
+                    local authorIdStr = ""
+                    while i <= #message.text do
+                        local c = message.text:sub(i, i)
+                        if c == "," then break end
+                        authorIdStr = authorIdStr .. c
+                        i = i + 1
+                    end
+                    authorEntityId = math.tointeger(authorIdStr)
                 end
-                return false
-            end
-            local authorRendered = world.entityExists(authorEntityId)
-
-            local handleMessage = function(receiverEntityId, copiedMessage)
-                local message = copiedMessage or message
-                if xsb then
-                    if copiedMessage or message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
-                        local receiverName = world.entityName(receiverEntityId)
-                        if #ownPlayers ~= 1 then message.nickname = message.nickname .. " -> " .. receiverName end
-                        if receiverEntityId ~= player.id() then message.mode = "ProxSecondary" end
+                -- FezzedOne: Allows OpenStarbound and StarExtensions clients to correctly display received messages from xStarbound clients.
+                authorEntityId = authorEntityId or message.sourceId or (message.connection * -65536)
+                local authorRendered = world.entityExists(authorEntityId)
+                -- FezzedOne: If the author ID has to be guessed from the connection ID and it's *not* the first ID, that means the author is using xStarbound,
+                -- so look for the first rendered player belonging to the author's client. Kinda kludgy, but this is what we have to do for xStarbound clients
+                -- that don't send the required information because they don't have this mod!
+                if not (authorRendered or hasAuthorPrefix or message.sourceId) then
+                    for i = (message.connection * -65536 + 1), (message.connection * -65536 + 255), 1 do
+                        if world.entityExists(i) and world.entityType(i) == "player" then
+                            authorEntityId = i
+                            break
+                        end
                     end
                 end
-                if message.contentIsText or world.entityExists(authorEntityId) then
-                    local authorPos, messageDistance, inSight = nil, math.huge, false
-                    local playerPos =
-                        world.entityPosition(world.entityExists(receiverEntityId) and receiverEntityId or player.id())
-                    if authorRendered then
-                        authorPos = world.entityPosition(authorEntityId)
-                        messageDistance = world.magnitude(playerPos, authorPos)
-                        -- messageDistance = 30
-                        inSight = not world.lineTileCollision(authorPos, playerPos, { "Block", "Dynamic" }) --not doing dynamic, i think that's only for open doors
+                local receiverEntityId = message.targetId or player.id()
+                local ownPlayers = world.ownPlayers()
+                local isLocalPlayer = function(entityId)
+                    if not xsb then return true end
+                    for _, plr in ipairs(ownPlayers) do
+                        if entityId == plr then return true end
                     end
+                    return false
+                end
 
-                    -- this is for later, testing to see if i can calculate how many tiles are between a sender and receiver
-                    -- local testCol = world.lineTileCollisionPoint(authorPos, playerPos, { "Block", "Dynamic" })
-                    -- sb.logWarn("messageDistance is " .. messageDistance)
-                    -- if testCol ~= nil then
-                    --   sb.logInfo("testCol is " .. dump(testCol))
-                    --   local pos1 = testCol[1][1]
-                    --   local pos2 = testCol[1][2]
-                    --   sb.logInfo("pos1 "..pos1.." pos2 "..pos2)
-                    --   sb.logInfo("distance is " .. world.magnitude(pos1, pos2))
-                    -- end
-                    local randSource = sb.makeRandomSource()
-
-                    local actionRad = self.proxActionRadius -- FezzedOne: Un-hardcoded the action radius.
-                    local loocRad = self.proxOocRadius -- actionRad * 2 -- FezzedOne: Un-hardcoded the local OOC radius.
-                    local noiseRad = self.proxTalkRadius -- FezzedOne: Un-hardcoded the talking radius.
-
-                    --originally i made this a function, but tracking the values is difficult and it's easier to manually set them since there are only 9
-                    local soundTable = {
-                        [-4] = noiseRad / 10,
-                        [-3] = noiseRad / 5,
-                        [-2] = noiseRad / 4,
-                        [-1] = noiseRad / 2,
-                        [0] = noiseRad, --based on the default range of talking being 50, this should be good
-                        [1] = noiseRad * 1.5,
-                        [2] = noiseRad * 2,
-                        [3] = noiseRad * 3,
-                        [4] = noiseRad * 5,
-                    }
-
-                    --i dont like this but it'll have to do
-                    local volTable = {
-                        [noiseRad / 10] = -4,
-                        [noiseRad / 5] = -3,
-                        [noiseRad / 4] = -2,
-                        [noiseRad / 2] = -1,
-                        [noiseRad] = 0, --based on the default range of talking being 50, this should be good
-                        [noiseRad * 1.5] = 1,
-                        [noiseRad * 2] = 2,
-                        [noiseRad * 3] = 3,
-                        [noiseRad * 5] = 4,
-                    }
-
-                    local tVol, sVol = 0, 0
-                    local tVolRad = noiseRad
-                    local sVolRad = noiseRad
-                    --iterate through message and get components here
-                    local curMode = "action"
-                    local prevMode = "action"
-                    local prevDiffMode = "action"
-                    local maxRad = 0
-                    local rawText = message.text
-                    local debugTable = {} --this will eventually be smashed together to make filterText
-                    local textTable = {} --this will eventually be smashed together to make filterText
-                    local validSum = 0 --number of valid entries in the table
-                    local cInd = 1 --lua starts at 1 >:(
-                    local charBuffer = ""
-                    local languageCode = message.defaultLang --the !! shouldn't need to be set, but i'll leave it anyway
-                    local radioMode = false --radio flag
-
-                    local modeRadTypes = {
-                        action = function() return actionRad end,
-                        quote = function() return tVolRad end,
-                        sound = function() return sVolRad end,
-                        lOOC = function() return loocRad end,
-                        gOOC = function() return -1 end,
-                    }
-
-                    local function rawSub(sInd, eInd) return rawText:sub(sInd, eInd) end
-
-                    --use this to construct the components
-                    --any component indications (like :+) that remain should stay, use them for coloring if they aren't picked up here and reset after each component
-                    local function formatInsert(str, radius, type, langKey, isValid, msgQuality, inSight, isRadio)
-                        if langKey == nil then langKey = "!!" end
-
-                        if msgQuality < 0 then msgQuality = 100 end
-
-                        table.insert(textTable, {
-                            text = str,
-                            radius = radius,
-                            type = type,
-                            langKey = langKey,
-                            valid = isValid,
-                            msgQuality = msgQuality,
-                            hasLOS = inSight,
-                            isRadio = isRadio,
-                        })
+                local handleMessage = function(receiverEntityId, copiedMessage)
+                    local message = copiedMessage or message
+                    if xsb then
+                        if copiedMessage or message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
+                            local receiverName = world.entityName(receiverEntityId)
+                            if #ownPlayers ~= 1 then message.nickname = message.nickname .. " -> " .. receiverName end
+                            if receiverEntityId ~= player.id() then message.mode = "ProxSecondary" end
+                        end
                     end
-
-                    local function parseDefault(letter)
-                        charBuffer = charBuffer .. letter
-                        cInd = cInd + 1
-                    end
-
-                    local function newMode(nextMode) --if radius is -1, the insert is instance wide
-                        if #charBuffer < 1 or charBuffer == '"' or charBuffer == ">" or charBuffer == "<" then
-                            prevMode = curMode
-                            curMode = nextMode
-                            return
+                    if message.contentIsText or world.entityExists(authorEntityId) then
+                        local authorPos, messageDistance, inSight = nil, math.huge, false
+                        local playerPos = world.entityPosition(
+                            world.entityExists(receiverEntityId) and receiverEntityId or player.id()
+                        )
+                        if authorRendered then
+                            authorPos = world.entityPosition(authorEntityId)
+                            messageDistance = world.magnitude(playerPos, authorPos)
+                            -- messageDistance = 30
+                            inSight = not world.lineTileCollision(authorPos, playerPos, { "Block", "Dynamic" }) --not doing dynamic, i think that's only for open doors
                         end
 
-                        local useRad
-                        useRad = modeRadTypes[curMode]()
-                        local isValid = false --start with false
-                        if messageDistance <= useRad or useRad == -1 then --if in range
-                            isValid = true --the message is valid
-                            if inSight == false and curMode == "action" then --if i can't see you and the mode is action
-                                isValid = false --the message isn't valid anymore
-                            elseif inSight == false and (curMode == "quote" or curMode == "sound") then --else, if i can't see you and the mode is quote or sound
-                                --check for path
-                                local noPathVol
-                                if authorPos then
-                                    if
-                                        world.findPlatformerPath(
-                                            authorPos,
-                                            playerPos,
-                                            root.monsterMovementSettings("smallflying")
-                                        )
-                                    then --if path is found
-                                        noPathVol = volTable[useRad] - 1 --set the volume to 1 (maybe 2 later on) level lower
-                                    else --if the path isn't found
-                                        noPathVol = volTable[useRad] - 4 --set the volume to 4 levels lower
-                                    end
-                                else
-                                    noPathVol = -4
-                                end
-                                if noPathVol > 4 then
-                                    noPathVol = 4
-                                elseif noPathVol < -4 then
-                                    noPathVol = -4
-                                    isValid = false
-                                end
-                                useRad = soundTable[noPathVol] --set the radius to whatever the soundelevel would be
-                                isValid = isValid and messageDistance <= useRad --set isvalid to the new value if it's still true
-                            end
+                        -- this is for later, testing to see if i can calculate how many tiles are between a sender and receiver
+                        -- local testCol = world.lineTileCollisionPoint(authorPos, playerPos, { "Block", "Dynamic" })
+                        -- sb.logWarn("messageDistance is " .. messageDistance)
+                        -- if testCol ~= nil then
+                        --   sb.logInfo("testCol is " .. dump(testCol))
+                        --   local pos1 = testCol[1][1]
+                        --   local pos2 = testCol[1][2]
+                        --   sb.logInfo("pos1 "..pos1.." pos2 "..pos2)
+                        --   sb.logInfo("distance is " .. world.magnitude(pos1, pos2))
+                        -- end
+                        local randSource = sb.makeRandomSource()
+
+                        local actionRad = self.proxActionRadius -- FezzedOne: Un-hardcoded the action radius.
+                        local loocRad = self.proxOocRadius -- actionRad * 2 -- FezzedOne: Un-hardcoded the local OOC radius.
+                        local noiseRad = self.proxTalkRadius -- FezzedOne: Un-hardcoded the talking radius.
+
+                        --originally i made this a function, but tracking the values is difficult and it's easier to manually set them since there are only 9
+                        local soundTable = {
+                            [-4] = noiseRad / 10,
+                            [-3] = noiseRad / 5,
+                            [-2] = noiseRad / 4,
+                            [-1] = noiseRad / 2,
+                            [0] = noiseRad, --based on the default range of talking being 50, this should be good
+                            [1] = noiseRad * 1.5,
+                            [2] = noiseRad * 2,
+                            [3] = noiseRad * 3,
+                            [4] = noiseRad * 5,
+                        }
+
+                        --i dont like this but it'll have to do
+                        local volTable = {
+                            [noiseRad / 10] = -4,
+                            [noiseRad / 5] = -3,
+                            [noiseRad / 4] = -2,
+                            [noiseRad / 2] = -1,
+                            [noiseRad] = 0, --based on the default range of talking being 50, this should be good
+                            [noiseRad * 1.5] = 1,
+                            [noiseRad * 2] = 2,
+                            [noiseRad * 3] = 3,
+                            [noiseRad * 5] = 4,
+                        }
+
+                        local tVol, sVol = 0, 0
+                        local tVolRad = noiseRad
+                        local sVolRad = noiseRad
+                        --iterate through message and get components here
+                        local curMode = "action"
+                        local prevMode = "action"
+                        local prevDiffMode = "action"
+                        local maxRad = 0
+                        local rawText = message.text
+                        local debugTable = {} --this will eventually be smashed together to make filterText
+                        local textTable = {} --this will eventually be smashed together to make filterText
+                        local validSum = 0 --number of valid entries in the table
+                        local cInd = 1 --lua starts at 1 >:(
+                        local charBuffer = ""
+                        local languageCode = message.defaultLang --the !! shouldn't need to be set, but i'll leave it anyway
+                        local radioMode = false --radio flag
+
+                        local modeRadTypes = {
+                            action = function() return actionRad end,
+                            quote = function() return tVolRad end,
+                            sound = function() return sVolRad end,
+                            lOOC = function() return loocRad end,
+                            gOOC = function() return -1 end,
+                        }
+
+                        local function rawSub(sInd, eInd) return rawText:sub(sInd, eInd) end
+
+                        --use this to construct the components
+                        --any component indications (like :+) that remain should stay, use them for coloring if they aren't picked up here and reset after each component
+                        local function formatInsert(str, radius, type, langKey, isValid, msgQuality, inSight, isRadio)
+                            if langKey == nil then langKey = "!!" end
+
+                            if msgQuality < 0 then msgQuality = 100 end
+
+                            table.insert(textTable, {
+                                text = str,
+                                radius = radius,
+                                type = type,
+                                langKey = langKey,
+                                valid = isValid,
+                                msgQuality = msgQuality,
+                                hasLOS = inSight,
+                                isRadio = isRadio,
+                            })
                         end
 
-                        local msgQuality = 0
-                        if isValid then
-                            validSum = validSum + 1
-                            msgQuality = math.min(((useRad / 2) / messageDistance) * 100, 100) --basically, check half the radius and take the percentage of that vs the message distance, cap at 100
-                            maxRad = math.max(maxRad, useRad)
-                        end
-
-                        if useRad == -1 and maxRad ~= -1 then maxRad = -1 end
-                        formatInsert(charBuffer, useRad, curMode, languageCode, isValid, msgQuality, inSight, radioMode)
-                        charBuffer = ""
-
-                        prevMode = curMode
-                        if curMode ~= nextMode then prevDiffMode = curMode end
-                        curMode = nextMode
-                    end
-
-                    local defaultKey = getDefaultLang()
-
-                    local mode_table = {
-                        ['"'] = function()
-                            if curMode == "quote" then
-                                parseDefault("")
-                                newMode("action")
-                            elseif curMode == "action" then
-                                newMode("quote")
-                                parseDefault("")
-                            else
-                                parseDefault('"')
-                            end
-                        end,
-                        ["<"] = function() --i could combine these two, but i don't want to
-                            if curMode ~= "sound" and curMode ~= "quote" then --added quotes here so people can do the cool combine vocoder thing <::Pick up that can.::>
-                                newMode("sound")
-                            end
-                            parseDefault("")
-                        end,
-                        [">"] = function()
-                            parseDefault("")
-                            if curMode == "sound" then newMode(prevDiffMode) end
-                        end,
-                        [":"] = function()
-                            local nextChar = rawSub(cInd + 1, cInd + 1)
-                            if nextChar == "+" or nextChar == "-" or nextChar == "=" then
-                                newMode(curMode) --this happens to change volume, but mode isn't actually changing
-
-                                local maxAmp = 4 --maximum chars after the colon
-
-                                local lStart, lEnd = rawText:find(":%++", cInd)
-                                local qStart, qEnd = rawText:find(":%-+", cInd)
-                                local eStart, eEnd = rawText:find(":%=+", cInd)
-                                local nCStart, nCEnd
-
-                                if qStart == nil then qStart = #rawText end
-                                if qEnd == nil then qEnd = #rawText end
-                                if lStart == nil then lStart = #rawText end
-                                if lEnd == nil then lEnd = #rawText end
-                                if eStart == nil then eStart = #rawText end
-                                if eEnd == nil then eEnd = #rawText end
-
-                                if math.min(eStart, lStart, qStart) == eStart then
-                                    nCStart = eStart
-                                    nCEnd = eEnd
-                                elseif math.min(eStart, lStart, qStart) == lStart then
-                                    nCStart = lStart
-                                    nCEnd = lEnd
-                                elseif math.min(eStart, lStart, qStart) == qStart then
-                                    nCStart = qStart
-                                    nCEnd = qEnd
-                                end
-
-                                local doVolume = "none"
-                                --in these modes, ignore the volume controls
-                                if curMode == "radio" or curMode == "gOOC" or curMode == "lOOC" then
-                                    cInd = nCEnd + 1
-                                elseif curMode == "action" then
-                                    local nextInd = rawText:find('["<]', cInd)
-
-                                    if nextChar == nil then --if they just put this at the end for some reason
-                                        cInd = nCEnd + 1
-                                    elseif nextInd ~= nil then
-                                        nextChar = rawSub(nextInd, nextInd)
-                                    end
-                                    if nextChar == '"' then
-                                        doVolume = "quote"
-                                    else
-                                        doVolume = "sound"
-                                    end
-                                else
-                                    doVolume = curMode
-                                end
-
-                                if doVolume ~= "none" then
-                                    local sum = 0
-                                    local nextStr = rawSub(nCStart + 1, nCEnd)
-
-                                    if doVolume == "quote" then
-                                        sum = tVol
-                                    else
-                                        sum = sVol
-                                    end
-
-                                    for i in nextStr:gmatch(".") do
-                                        if i == "+" then
-                                            sum = sum + 1
-                                        elseif i == "-" then
-                                            sum = sum - 1
-                                        elseif i == "=" then
-                                            sum = 0
-                                            if doVolume == "quote" then
-                                                tVolRad = noiseRad
-                                            else
-                                                sVolRad = noiseRad
-                                            end
-                                        end
-                                    end
-                                    cInd = nCEnd
-
-                                    sum = math.min(math.max(sum, -4), 4)
-
-                                    if doVolume == "quote" then
-                                        tVol = sum
-                                        tVolRad = soundTable[sum]
-                                    else
-                                        sVol = sum
-                                        sVolRad = soundTable[sum]
-                                    end
-                                end
-                                cInd = nCEnd + 1
-                            else
-                                parseDefault(":")
-                            end
-                        end,
-                        ["*"] = function() --leave this for the visual alterations later on
-                            -- i have this commented out so people can keep asterisks in actions if they want
-                            -- if curMode == 'action' then
-                            --   cInd = cInd + 1
-                            -- else
-                            --   parseDefault("*")
-                            -- end
-                            parseDefault("*")
-                        end,
-                        ["/"] = function() parseDefault("/") end,
-                        ["`"] = function() parseDefault("`") end,
-                        ["\\"] = function() -- Allow escaping any specially parsed character with `\`.
-                            local nextChar = rawSub(cInd + 1, cInd + 1)
-                            parseDefault(nextChar)
-                            cInd = cInd + 1
-                        end,
-                        ["("] = function() --check for number of parentheses
-                            local nextChar = rawSub(cInd + 1, cInd + 1)
-                            if nextChar == "(" then
-                                local oocEnd = 0
-                                local oocBump = 0
-                                local oocType
-                                local oocRad
-                                if rawSub(cInd + 2, cInd + 2) == "(" then
-                                    --global ooc
-                                    _, oocEnd = rawText:find("%)%)%)+", cInd) --the + catches extra parentheses in case someone adds more than 3
-                                    oocType = "gOOC"
-                                    oocBump = 2
-                                    oocRad = -1
-                                else
-                                    --local ooc
-                                    _, oocEnd = rawText:find("%)%)+", cInd)
-                                    oocBump = 1
-                                    oocType = "lOOC"
-                                    oocRad = actionRad * 2
-                                end
-
-                                if oocEnd ~= nil then
-                                    newMode(oocType)
-                                    charBuffer = charBuffer .. rawSub(cInd, oocEnd)
-                                    newMode(prevMode)
-                                else
-                                    charBuffer = charBuffer .. rawSub(cInd, cInd + oocBump)
-                                    cInd = cInd + oocBump
-                                    oocEnd = cInd
-                                end
-
-                                cInd = oocEnd + 1
-                            else
-                                parseDefault("(")
-                            end
-                        end,
-                        ["{"] = function() --this should function as a global IC message, but finding the playercount is not possible (or i'm stupid) clientside
-                            --i'm not doing secure radio because you can edit this file and ignore the password requirement with it
-                            --if you want to do that, just do it over group chat or something
-                            --this is where a stagehand serverside would be useful. In the future it might be worth exploring that
-
-                            --maybe set up multiple radio ranges with multiple brackets? seems kind of pointless imo
-                            newMode(curMode)
-                            radioMode = true
-                            parseDefault("{")
-                        end,
-                        ["}"] = function()
-                            if rawSub(cInd + 1, cInd + 1) == '"' and curMode == "quote" then
-                                parseDefault("}")
-                                parseDefault('"')
-                                newMode("action")
-                            else
-                                parseDefault("}")
-                                newMode(curMode)
-                            end
-
-                            radioMode = false
-                            -- cInd = cInd + 1
-                        end,
-                        -- ["|"] = function()
-                        --     local fStart = cInd
-                        --     local fEnd = rawText:find("|", cInd + 1)
-                        --
-                        --     if fStart ~= nil and fEnd ~= nil then
-                        --         -- local timeNum = tostring(math.floor(os.time()))
-                        --         -- local mixNum = tonumber(timeNum .. math.abs(authorEntityId))
-                        --         -- randSource:init(mixNum)
-                        --         -- local numMax = rawSub(fStart, fEnd - 1):gsub("%D", "")
-                        --         -- local roll = randSource:randInt(1, tonumber(numMax) or 20)
-                        --         -- FezzedOne: Replaced dice roller with the more flexible one from FezzedTech.
-                        --         local diceResults = rawSub(fStart + 1, fEnd):gsub("[ ]*", ""):gsub(
-                        --             "(.-)[,|]",
-                        --             function(die) return tostring(rollDice(die) or "n/a") .. ", " end
-                        --         )
-                        --         parseDefault("|" .. diceResults:sub(1, -3) .. "|")
-                        --         cInd = fEnd + 1
-                        --     else
-                        --         parseDefault("|")
-                        --     end
-                        -- end,
-                        ["["] = function()
-                            -- FezzedOne: Added escape code handling.
-                            local fStart = cInd
-                            local fEnd = rawText:find("[^\\]%]", cInd + 1)
-                            if rawSub(cInd, cInd + 1) == "[[" then
-                                parseDefault("[[")
-                                cInd = cInd + 1
-                            elseif rawSub(cInd, cInd + 1) == "[]" then --this should never happen anymore
-                                newMode(curMode)
-                                languageCode = defaultKey
-                                cInd = cInd + 2
-                            elseif fStart ~= nil and fEnd ~= nil then
-                                local newCode = rawSub(fStart + 1, fEnd)
-
-                                if languageCode ~= newCode and curMode == "quote" then newMode(curMode) end
-                                languageCode = newCode:upper()
-                                cInd = rawText:find("%S", fEnd + 2) or #rawText --set index to the next non whitespace character after the code
-                            else
-                                parseDefault("[")
-                            end
-                        end,
-                        default = function(letter)
+                        local function parseDefault(letter)
                             charBuffer = charBuffer .. letter
                             cInd = cInd + 1
-                        end,
-                    }
-
-                    local c
-
-                    --run this loop to generate textTable, then concatenate
-                    while cInd <= #rawText do
-                        c = rawSub(cInd, cInd)
-
-                        if mode_table[c] then
-                            mode_table[c]()
-                        else
-                            parseDefault(c)
                         end
-                    end
-                    newMode(curMode) --makes sure nothing is left out
 
-                    local function trim(s)
-                        local l = 1
-                        while string.sub(s, l, l) == " " do
-                            l = l + 1
-                        end
-                        local r = #s
-                        while string.sub(s, r, r) == " " do
-                            r = r - 1
-                        end
-                        return string.sub(s, l, r)
-                    end
+                        local function newMode(nextMode) --if radius is -1, the insert is instance wide
+                            if #charBuffer < 1 or charBuffer == '"' or charBuffer == ">" or charBuffer == "<" then
+                                prevMode = curMode
+                                curMode = nextMode
+                                return
+                            end
 
-                    local function degradeMessage(str, quality)
-                        local returnStr = ""
-                        local char
-                        local iCount = 1
-                        local rMax = (#str - 2) - ((#str - 2) * (quality / 100)) --basically, how many characters can be "-", helps
-                        local rCount = 0
-                        while iCount <= #str do
-                            char = str:sub(iCount, iCount)
-                            if char == "\\" then
-                                returnStr = returnStr .. str:sub(iCount + 1, iCount + 1)
-                                iCount = iCount + 2
-                            -- FezzedOne: Got rid of hardcoded assumption that language codes are two characters long.
-                            elseif char == "[" and str:find("]", iCount) ~= nil then
-                                local closingBracket = str:find("]", iCount)
-                                returnStr = returnStr .. str:sub(iCount, closingBracket)
-                                iCount = closingBracket + 1
-                            elseif char == "^" and str:find(";", iCount) ~= nil then
-                                local nextSemi = str:find(";", iCount)
-                                returnStr = returnStr .. str:sub(iCount, nextSemi)
-                                iCount = nextSemi + 1
+                            local useRad
+                            useRad = modeRadTypes[curMode]()
+                            local isValid = false --start with false
+                            if messageDistance <= useRad or useRad == -1 then --if in range
+                                isValid = true --the message is valid
+                                if inSight == false and curMode == "action" then --if i can't see you and the mode is action
+                                    isValid = false --the message isn't valid anymore
+                                elseif inSight == false and (curMode == "quote" or curMode == "sound") then --else, if i can't see you and the mode is quote or sound
+                                    --check for path
+                                    local noPathVol
+                                    if authorPos then
+                                        if
+                                            world.findPlatformerPath(
+                                                authorPos,
+                                                playerPos,
+                                                root.monsterMovementSettings("smallflying")
+                                            )
+                                        then --if path is found
+                                            noPathVol = volTable[useRad] - 1 --set the volume to 1 (maybe 2 later on) level lower
+                                        else --if the path isn't found
+                                            noPathVol = volTable[useRad] - 4 --set the volume to 4 levels lower
+                                        end
+                                    else
+                                        noPathVol = -4
+                                    end
+                                    if noPathVol > 4 then
+                                        noPathVol = 4
+                                    elseif noPathVol < -4 then
+                                        noPathVol = -4
+                                        isValid = false
+                                    end
+                                    useRad = soundTable[noPathVol] --set the radius to whatever the soundelevel would be
+                                    isValid = isValid and messageDistance <= useRad --set isvalid to the new value if it's still true
+                                end
+                            end
+
+                            local msgQuality = 0
+                            if isValid then
+                                validSum = validSum + 1
+                                msgQuality = math.min(((useRad / 2) / messageDistance) * 100, 100) --basically, check half the radius and take the percentage of that vs the message distance, cap at 100
+                                maxRad = math.max(maxRad, useRad)
+                            end
+
+                            if useRad == -1 and maxRad ~= -1 then maxRad = -1 end
+                            formatInsert(
+                                charBuffer,
+                                useRad,
+                                curMode,
+                                languageCode,
+                                isValid,
+                                msgQuality,
+                                inSight,
+                                radioMode
+                            )
+                            charBuffer = ""
+
+                            prevMode = curMode
+                            if curMode ~= nextMode then prevDiffMode = curMode end
+                            curMode = nextMode
+                        end
+
+                        local defaultKey = getDefaultLang()
+
+                        local mode_table = {
+                            ['"'] = function()
+                                if curMode == "quote" then
+                                    parseDefault("")
+                                    newMode("action")
+                                elseif curMode == "action" then
+                                    newMode("quote")
+                                    parseDefault("")
+                                else
+                                    parseDefault('"')
+                                end
+                            end,
+                            ["<"] = function() --i could combine these two, but i don't want to
+                                if curMode ~= "sound" and curMode ~= "quote" then --added quotes here so people can do the cool combine vocoder thing <::Pick up that can.::>
+                                    newMode("sound")
+                                end
+                                parseDefault("")
+                            end,
+                            [">"] = function()
+                                parseDefault("")
+                                if curMode == "sound" then newMode(prevDiffMode) end
+                            end,
+                            [":"] = function()
+                                local nextChar = rawSub(cInd + 1, cInd + 1)
+                                if nextChar == "+" or nextChar == "-" or nextChar == "=" then
+                                    newMode(curMode) --this happens to change volume, but mode isn't actually changing
+
+                                    local maxAmp = 4 --maximum chars after the colon
+
+                                    local lStart, lEnd = rawText:find(":%++", cInd)
+                                    local qStart, qEnd = rawText:find(":%-+", cInd)
+                                    local eStart, eEnd = rawText:find(":%=+", cInd)
+                                    local nCStart, nCEnd
+
+                                    if qStart == nil then qStart = #rawText end
+                                    if qEnd == nil then qEnd = #rawText end
+                                    if lStart == nil then lStart = #rawText end
+                                    if lEnd == nil then lEnd = #rawText end
+                                    if eStart == nil then eStart = #rawText end
+                                    if eEnd == nil then eEnd = #rawText end
+
+                                    if math.min(eStart, lStart, qStart) == eStart then
+                                        nCStart = eStart
+                                        nCEnd = eEnd
+                                    elseif math.min(eStart, lStart, qStart) == lStart then
+                                        nCStart = lStart
+                                        nCEnd = lEnd
+                                    elseif math.min(eStart, lStart, qStart) == qStart then
+                                        nCStart = qStart
+                                        nCEnd = qEnd
+                                    end
+
+                                    local doVolume = "none"
+                                    --in these modes, ignore the volume controls
+                                    if curMode == "radio" or curMode == "gOOC" or curMode == "lOOC" then
+                                        cInd = nCEnd + 1
+                                    elseif curMode == "action" then
+                                        local nextInd = rawText:find('["<]', cInd)
+
+                                        if nextChar == nil then --if they just put this at the end for some reason
+                                            cInd = nCEnd + 1
+                                        elseif nextInd ~= nil then
+                                            nextChar = rawSub(nextInd, nextInd)
+                                        end
+                                        if nextChar == '"' then
+                                            doVolume = "quote"
+                                        else
+                                            doVolume = "sound"
+                                        end
+                                    else
+                                        doVolume = curMode
+                                    end
+
+                                    if doVolume ~= "none" then
+                                        local sum = 0
+                                        local nextStr = rawSub(nCStart + 1, nCEnd)
+
+                                        if doVolume == "quote" then
+                                            sum = tVol
+                                        else
+                                            sum = sVol
+                                        end
+
+                                        for i in nextStr:gmatch(".") do
+                                            if i == "+" then
+                                                sum = sum + 1
+                                            elseif i == "-" then
+                                                sum = sum - 1
+                                            elseif i == "=" then
+                                                sum = 0
+                                                if doVolume == "quote" then
+                                                    tVolRad = noiseRad
+                                                else
+                                                    sVolRad = noiseRad
+                                                end
+                                            end
+                                        end
+                                        cInd = nCEnd
+
+                                        sum = math.min(math.max(sum, -4), 4)
+
+                                        if doVolume == "quote" then
+                                            tVol = sum
+                                            tVolRad = soundTable[sum]
+                                        else
+                                            sVol = sum
+                                            sVolRad = soundTable[sum]
+                                        end
+                                    end
+                                    cInd = nCEnd + 1
+                                else
+                                    parseDefault(":")
+                                end
+                            end,
+                            ["*"] = function() --leave this for the visual alterations later on
+                                -- i have this commented out so people can keep asterisks in actions if they want
+                                -- if curMode == 'action' then
+                                --   cInd = cInd + 1
+                                -- else
+                                --   parseDefault("*")
+                                -- end
+                                parseDefault("*")
+                            end,
+                            ["/"] = function() parseDefault("/") end,
+                            ["`"] = function() parseDefault("`") end,
+                            ["\\"] = function() -- Allow escaping any specially parsed character with `\`.
+                                local nextChar = rawSub(cInd + 1, cInd + 1)
+                                parseDefault(nextChar)
+                                cInd = cInd + 1
+                            end,
+                            ["("] = function() --check for number of parentheses
+                                local nextChar = rawSub(cInd + 1, cInd + 1)
+                                if nextChar == "(" then
+                                    local oocEnd = 0
+                                    local oocBump = 0
+                                    local oocType
+                                    local oocRad
+                                    if rawSub(cInd + 2, cInd + 2) == "(" then
+                                        --global ooc
+                                        _, oocEnd = rawText:find("%)%)%)+", cInd) --the + catches extra parentheses in case someone adds more than 3
+                                        oocType = "gOOC"
+                                        oocBump = 2
+                                        oocRad = -1
+                                    else
+                                        --local ooc
+                                        _, oocEnd = rawText:find("%)%)+", cInd)
+                                        oocBump = 1
+                                        oocType = "lOOC"
+                                        oocRad = actionRad * 2
+                                    end
+
+                                    if oocEnd ~= nil then
+                                        newMode(oocType)
+                                        charBuffer = charBuffer .. rawSub(cInd, oocEnd)
+                                        newMode(prevMode)
+                                    else
+                                        charBuffer = charBuffer .. rawSub(cInd, cInd + oocBump)
+                                        cInd = cInd + oocBump
+                                        oocEnd = cInd
+                                    end
+
+                                    cInd = oocEnd + 1
+                                else
+                                    parseDefault("(")
+                                end
+                            end,
+                            ["{"] = function() --this should function as a global IC message, but finding the playercount is not possible (or i'm stupid) clientside
+                                --i'm not doing secure radio because you can edit this file and ignore the password requirement with it
+                                --if you want to do that, just do it over group chat or something
+                                --this is where a stagehand serverside would be useful. In the future it might be worth exploring that
+
+                                --maybe set up multiple radio ranges with multiple brackets? seems kind of pointless imo
+                                newMode(curMode)
+                                radioMode = true
+                                parseDefault("{")
+                            end,
+                            ["}"] = function()
+                                if rawSub(cInd + 1, cInd + 1) == '"' and curMode == "quote" then
+                                    parseDefault("}")
+                                    parseDefault('"')
+                                    newMode("action")
+                                else
+                                    parseDefault("}")
+                                    newMode(curMode)
+                                end
+
+                                radioMode = false
+                                -- cInd = cInd + 1
+                            end,
+                            -- ["|"] = function()
+                            --     local fStart = cInd
+                            --     local fEnd = rawText:find("|", cInd + 1)
+                            --
+                            --     if fStart ~= nil and fEnd ~= nil then
+                            --         -- local timeNum = tostring(math.floor(os.time()))
+                            --         -- local mixNum = tonumber(timeNum .. math.abs(authorEntityId))
+                            --         -- randSource:init(mixNum)
+                            --         -- local numMax = rawSub(fStart, fEnd - 1):gsub("%D", "")
+                            --         -- local roll = randSource:randInt(1, tonumber(numMax) or 20)
+                            --         -- FezzedOne: Replaced dice roller with the more flexible one from FezzedTech.
+                            --         local diceResults = rawSub(fStart + 1, fEnd):gsub("[ ]*", ""):gsub(
+                            --             "(.-)[,|]",
+                            --             function(die) return tostring(rollDice(die) or "n/a") .. ", " end
+                            --         )
+                            --         parseDefault("|" .. diceResults:sub(1, -3) .. "|")
+                            --         cInd = fEnd + 1
+                            --     else
+                            --         parseDefault("|")
+                            --     end
+                            -- end,
+                            ["["] = function()
+                                -- FezzedOne: Added escape code handling.
+                                local fStart = cInd
+                                local fEnd = rawText:find("[^\\]%]", cInd + 1)
+                                if rawSub(cInd, cInd + 1) == "[[" then
+                                    parseDefault("[[")
+                                    cInd = cInd + 1
+                                elseif rawSub(cInd, cInd + 1) == "[]" then --this should never happen anymore
+                                    newMode(curMode)
+                                    languageCode = defaultKey
+                                    cInd = cInd + 2
+                                elseif fStart ~= nil and fEnd ~= nil then
+                                    local newCode = rawSub(fStart + 1, fEnd)
+
+                                    if languageCode ~= newCode and curMode == "quote" then newMode(curMode) end
+                                    languageCode = newCode:upper()
+                                    cInd = rawText:find("%S", fEnd + 2) or #rawText --set index to the next non whitespace character after the code
+                                else
+                                    parseDefault("[")
+                                end
+                            end,
+                            default = function(letter)
+                                charBuffer = charBuffer .. letter
+                                cInd = cInd + 1
+                            end,
+                        }
+
+                        local c
+
+                        --run this loop to generate textTable, then concatenate
+                        while cInd <= #rawText do
+                            c = rawSub(cInd, cInd)
+
+                            if mode_table[c] then
+                                mode_table[c]()
                             else
-                                randSource:init()
-
-                                local letterRoll = randSource:randInt(1, 100)
-                                if letterRoll > quality and char:match("[%p%s]") == nil then
-                                    char = "-"
-                                    rCount = rCount + 1
-                                end
-                                returnStr = returnStr .. char
-                                iCount = iCount + 1
+                                parseDefault(c)
                             end
                         end
-                        return returnStr
-                    end
+                        newMode(curMode) --makes sure nothing is left out
 
-                    local function wordBytes(word)
-                        local returnNum = 0
-                        if not type(word) == "string" then return 0 end
-                        for char in word:gmatch(".") do
-                            char = char:lower()
-                            returnNum = returnNum * 16
-                            if not math.tointeger(returnNum) then returnNum = math.tointeger(2 ^ 48) end
-                            returnNum = returnNum + math.abs(string.byte(char) - 100)
-                        end
-                        return returnNum
-                    end
-
-                    local function langWordRep(word, proficiency, byteLC)
-                        -- FezzedOne: The wordRoll parameter is now used.
-                        local vowels = {
-                            "a",
-                            "e",
-                            "i",
-                            "o",
-                            "u",
-                            "y",
-                        }
-                        local consonants = {
-                            "b",
-                            "c",
-                            "d",
-                            "f",
-                            "g",
-                            "h",
-                            "j",
-                            "k",
-                            "l",
-                            "m",
-                            "n",
-                            "p",
-                            "q",
-                            "r",
-                            "s",
-                            "t",
-                            "v",
-                            "w",
-                            "x",
-                            "z",
-                        }
-                        -- FezzedOne: Merge a list into a Lua pattern. Assumes input doesn't contain any characters that need to be escaped.
-                        local function mergePattern(list)
-                            local pattern = "["
-                            for _, char in ipairs(list) do
-                                pattern = pattern .. char
+                        local function trim(s)
+                            local l = 1
+                            while string.sub(s, l, l) == " " do
+                                l = l + 1
                             end
-                            return pattern .. "]"
-                        end
-
-                        local pickInd = 0
-                        local newWord = ""
-                        local wordLength = #word
-                        randSource:init(math.tointeger(byteLC + wordBytes(word)))
-                        for char in word:gmatch(".") do
-                            local charLower = char:lower()
-                            local isLower = char == charLower
-                            local vowelPattern = mergePattern(vowels)
-                            local compFail = randSource:randInt(0, 150)
-                                > (proficiency - (wordLength ^ 2 + 10) / (math.max(1, proficiency - 50) / 5))
-                            if proficiency < 5 or compFail then -- FezzedOne: Added a chance that a word will be partially comprehensible.
-                                if charLower:match(vowelPattern) then
-                                    local randNum = randSource:randInt(1, #vowels)
-                                    char = vowels[randNum]
-                                elseif not char:match("[%p]") then -- Don't mess with punctuation.
-                                    local randNum = randSource:randInt(1, #consonants)
-                                    char = consonants[randNum]
-                                end
+                            local r = #s
+                            while string.sub(s, r, r) == " " do
+                                r = r - 1
                             end
-                            if not isLower then char = char:upper() end
-                            newWord = newWord .. char
-                        end
-                        return newWord
-                    end
-
-                    local function langScramble(str, prof, langCode, msgColor, langColor)
-                        local returnStr = ""
-                        str = str .. " "
-                        str = str:gsub("  ", " ")
-                        local rCount = 0
-                        local words = 0
-                        for i in str:gmatch(".") do
-                            if i == " " then words = words + 1 end
-                        end
-                        words = words + 1
-                        local rMax = words - (words * (prof / 100))
-                        local wordBuffer = ""
-                        local byteLC = wordBytes(langCode)
-                        local iCount = 1
-                        local char
-                        local effProf = 64 * math.log(prof / 3 + 1, 10)
-                        local uniqueIdBytes = wordBytes(
-                            (xsb and isLocalPlayer(receiverEntityId)) and world.entityUniqueId(receiverEntityId)
-                                or player.uniqueId()
-                        )
-
-                        if langColor == nil then
-                            local hexDigits =
-                                { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F" }
-                            local randSource = sb.makeRandomSource()
-                            local hexMin = 1
-
-                            --not sure if there's an cleaner way to do this
-                            randSource:init(math.tointeger(byteLC + wordBytes("Red One")))
-                            local rNumR = hexDigits[randSource:randInt(hexMin, 16)]
-                            randSource:init(math.tointeger(byteLC + wordBytes("Green Two")))
-                            local rNumG = hexDigits[randSource:randInt(hexMin, 16)]
-                            randSource:init(math.tointeger(byteLC + wordBytes("Blue Three")))
-                            local rNumB = hexDigits[randSource:randInt(hexMin, 16)]
-                            randSource:init(math.tointeger(byteLC + wordBytes("Red Four")))
-                            local rNumR2 = hexDigits[randSource:randInt(hexMin, 16)]
-                            randSource:init(math.tointeger(byteLC + wordBytes("Green Five")))
-                            local rNumG2 = hexDigits[randSource:randInt(hexMin, 16)]
-                            randSource:init(math.tointeger(byteLC + wordBytes("Blue Six")))
-                            local rNumB2 = hexDigits[randSource:randInt(hexMin, 16)]
-                            langColor = "#" .. rNumR .. rNumG .. rNumB .. rNumR2 .. rNumG2 .. rNumB2
+                            return string.sub(s, l, r)
                         end
 
-                        while iCount <= #str do
-                            char = str:sub(iCount, iCount)
-                            -- FezzedOne: Got rid of hardcoded assumption that language keys are two characters long.
-                            if char == "[" and str:find(iCount, "]") ~= nil then
-                                local closingBracket = str:find("]", iCount)
-                                returnStr = returnStr .. char .. str:sub(iCount + 1, closingBracket)
-                                iCount = closingBracket + 1
-                            elseif char == " " and not wordBuffer:match("%a") and #wordBuffer > 0 then
-                                returnStr = returnStr .. " " .. wordBuffer
-                                wordBuffer = ""
-                            elseif char ~= "'" and char:match("[%s%p]") then
-                                if #wordBuffer > 0 then
-                                    local wordLength = #wordBuffer
-                                    local byteWord = wordBytes(wordBuffer)
-                                    randSource:init(math.tointeger(uniqueIdBytes + byteLC + byteWord))
-                                    local wordRoll = randSource:randInt(1, 100)
-                                    if
-                                        effProf < 5
-                                        or (wordRoll + (wordLength ^ 2 / (math.max(1, effProf - 50) / 5)) - 10)
-                                            > effProf
-                                    then
-                                        wordBuffer = langWordRep(trim(wordBuffer), effProf, byteLC)
-                                        wordBuffer = "^" .. langColor .. ";" .. wordBuffer .. "^" .. msgColor .. ";"
+                        local function degradeMessage(str, quality)
+                            local returnStr = ""
+                            local char
+                            local iCount = 1
+                            local rMax = (#str - 2) - ((#str - 2) * (quality / 100)) --basically, how many characters can be "-", helps
+                            local rCount = 0
+                            while iCount <= #str do
+                                char = str:sub(iCount, iCount)
+                                if char == "\\" then
+                                    returnStr = returnStr .. str:sub(iCount + 1, iCount + 1)
+                                    iCount = iCount + 2
+                                -- FezzedOne: Got rid of hardcoded assumption that language codes are two characters long.
+                                elseif char == "[" and str:find("]", iCount) ~= nil then
+                                    local closingBracket = str:find("]", iCount)
+                                    returnStr = returnStr .. str:sub(iCount, closingBracket)
+                                    iCount = closingBracket + 1
+                                elseif char == "^" and str:find(";", iCount) ~= nil then
+                                    local nextSemi = str:find(";", iCount)
+                                    returnStr = returnStr .. str:sub(iCount, nextSemi)
+                                    iCount = nextSemi + 1
+                                else
+                                    randSource:init()
+
+                                    local letterRoll = randSource:randInt(1, 100)
+                                    if letterRoll > quality and char:match("[%p%s]") == nil then
+                                        char = "-"
                                         rCount = rCount + 1
                                     end
+                                    returnStr = returnStr .. char
+                                    iCount = iCount + 1
                                 end
-                                returnStr = returnStr .. wordBuffer .. char
-                                wordBuffer = ""
-                            else
-                                wordBuffer = wordBuffer .. char
                             end
-                            iCount = iCount + 1
+                            return returnStr
                         end
 
-                        if returnStr:match("%s", #returnStr) then returnStr = returnStr:sub(0, #returnStr - 1) end
+                        local function wordBytes(word)
+                            local returnNum = 0
+                            if not type(word) == "string" then return 0 end
+                            for char in word:gmatch(".") do
+                                char = char:lower()
+                                returnNum = returnNum * 16
+                                if not math.tointeger(returnNum) then returnNum = math.tointeger(2 ^ 48) end
+                                returnNum = returnNum + math.abs(string.byte(char) - 100)
+                            end
+                            return returnNum
+                        end
 
-                        randSource:init()
-                        return returnStr
-                    end
-
-                    local colorTable = { --transparency is an options here, but it makes things hard to read
-                        [-4] = "#555",
-                        [-3] = "#777",
-                        [-2] = "#999",
-                        [-1] = "#bbb",
-                        [0] = "#ddd",
-                        [1] = "#fff",
-                        [2] = "#daa",
-                        [3] = "#d66",
-                        [4] = "#d00",
-                    }
-
-                    local function colorWithin(str, char, color, prevColor)
-                        local colorOn = false
-                        local charBuffer = ""
-                        for i in str:gmatch(".") do
-                            if i == char then
-                                if colorOn == false then
-                                    charBuffer = charBuffer .. "^" .. color .. ";"
-                                    colorOn = true
-                                else
-                                    charBuffer = charBuffer .. "^" .. prevColor .. ";"
-                                    colorOn = false
+                        local function langWordRep(word, proficiency, byteLC)
+                            -- FezzedOne: The wordRoll parameter is now used.
+                            local vowels = {
+                                "a",
+                                "e",
+                                "i",
+                                "o",
+                                "u",
+                                "y",
+                            }
+                            local consonants = {
+                                "b",
+                                "c",
+                                "d",
+                                "f",
+                                "g",
+                                "h",
+                                "j",
+                                "k",
+                                "l",
+                                "m",
+                                "n",
+                                "p",
+                                "q",
+                                "r",
+                                "s",
+                                "t",
+                                "v",
+                                "w",
+                                "x",
+                                "z",
+                            }
+                            -- FezzedOne: Merge a list into a Lua pattern. Assumes input doesn't contain any characters that need to be escaped.
+                            local function mergePattern(list)
+                                local pattern = "["
+                                for _, char in ipairs(list) do
+                                    pattern = pattern .. char
                                 end
-                            else
-                                --put this outside the if statement to make the characters appear as well as colors
-                                charBuffer = charBuffer .. i
+                                return pattern .. "]"
                             end
-                        end
-                        -- print("Charbuffer is " .. charBuffer)
-                        return charBuffer
-                    end
 
-                    local function cleanDoubleSpaces(str)
-                        --run a loop with the string, ignore codes (^whatever;), then remove more than one space in a row
-                        local cleanStr = ""
-                        local iCount = 1
-                        local prevChar = ""
-                        local prevColor = ""
-
-                        while iCount <= #str do
-                            local char = str:sub(iCount, iCount)
-                            local nextSemi = 0
-
-                            if char == "^" then
-                                nextSemi = str:find(";", iCount)
-
-                                if nextSemi ~= nil then
-                                    local colorCode = str:sub(iCount, nextSemi)
-                                    if colorCode ~= prevColor then cleanStr = cleanStr .. colorCode end
-                                    prevColor = colorCode
-                                    iCount = nextSemi
-                                end
-                            elseif char ~= " " or prevChar ~= " " then
-                                cleanStr = cleanStr .. char
-                                prevChar = char
-                            end
-                            iCount = iCount + 1
-                        end
-                        cleanStr = cleanStr:gsub("%{ ", "{")
-                        cleanStr = cleanStr:gsub(" %}", "}")
-                        return cleanStr
-                    end
-
-                    --do visual formatting here.
-                    --for dialogue (NOT sounds), start degrading the quality of the message at 50% of the quotes's radius
-                    local tableStr = ""
-                    local prevStr = ""
-                    local quoteCombo = ""
-                    local soundCombo = ""
-                    local prevType = "action"
-                    local quoteOpen = false
-                    local soundOpen = false
-                    local hasValids = false
-                    local chunkStr
-                    local chunkType
-                    local langBank = {} --populate with languages in inventory when you find them
-                    local prevLang = getDefaultLang() --either the player's default language, or !!
-
-                    if maxRad ~= -1 and (messageDistance > maxRad and validSum == 0) then
-                        message.text = ""
-                    else
-                        chunkType = nil
-
-                        local prevChunk = ""
-                        local repeatFlag = false
-                        table.insert(textTable, {
-                            text = "",
-                            radius = "0",
-                            type = "bad",
-                            langKey = ":(",
-                            valid = false,
-                            msgQuality = 0,
-                        })
-
-                        for k, v in pairs(textTable) do
-                            if v["hasLOS"] == false and chunkType == "action" then v["valid"] = false end
-                            if v["valid"] then hasValids = true end
-                        end
-                        for k, v in pairs(textTable) do
-                            if v["radius"] == -1 or v["isRadio"] == true then v["valid"] = true end
-
-                            chunkStr = v["text"]
-                            chunkType = v["type"]
-                            local langKey = v["langKey"]
-                            if
-                                v["valid"] == true
-                                or (
-                                    chunkType == "quote"
-                                    and (
-                                        (k > 1 and textTable[k - 1]["type"] == "quote")
-                                        or (k < #textTable and textTable[k + 1]["type"] == "quote")
-                                    )
-                                )
-                            then --check if this is surrounded by quotes
-                                v["valid"] = true --this should be set to true in here, since everything in this block should show up on the screen
-                                -- remember, noiserad is a const and radius is for the message
-
-                                local colorOverride = chunkStr:find("%^%#") ~= nil --don't touch colors if this is true
-                                local actionColor = "#fff" --white for non sound based chunks
-                                local msgColor = "#fff" --white for non sound based chunks
-                                --disguise unheard stuff
-                                if chunkType == "sound" then
-                                    if not colorOverride then
-                                        msgColor = colorTable[volTable[v["radius"]]]
-                                        chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                            local pickInd = 0
+                            local newWord = ""
+                            local wordLength = #word
+                            randSource:init(math.tointeger(byteLC + wordBytes(word)))
+                            for char in word:gmatch(".") do
+                                local charLower = char:lower()
+                                local isLower = char == charLower
+                                local vowelPattern = mergePattern(vowels)
+                                local compFail = randSource:randInt(0, 150)
+                                    > (proficiency - (wordLength ^ 2 + 10) / (math.max(1, proficiency - 50) / 5))
+                                if proficiency < 5 or compFail then -- FezzedOne: Added a chance that a word will be partially comprehensible.
+                                    if charLower:match(vowelPattern) then
+                                        local randNum = randSource:randInt(1, #vowels)
+                                        char = vowels[randNum]
+                                    elseif not char:match("[%p]") then -- Don't mess with punctuation.
+                                        local randNum = randSource:randInt(1, #consonants)
+                                        char = consonants[randNum]
                                     end
-                                elseif chunkType == "quote" then
-                                    msgColor = colorTable[volTable[v["radius"]]]
+                                end
+                                if not isLower then char = char:upper() end
+                                newWord = newWord .. char
+                            end
+                            return newWord
+                        end
 
-                                    if chunkType == "quote" and langKey ~= "!!" then
-                                        local langProf, langColor
-                                        if langBank[langKey] ~= nil then
-                                            langProf = langBank[langKey]["prof"]
-                                            langColor = langBank[langKey]["color"]
+                        local function langScramble(str, prof, langCode, msgColor, langColor)
+                            local returnStr = ""
+                            str = str .. " "
+                            str = str:gsub("  ", " ")
+                            local rCount = 0
+                            local words = 0
+                            for i in str:gmatch(".") do
+                                if i == " " then words = words + 1 end
+                            end
+                            words = words + 1
+                            local rMax = words - (words * (prof / 100))
+                            local wordBuffer = ""
+                            local byteLC = wordBytes(langCode)
+                            local iCount = 1
+                            local char
+                            local effProf = 64 * math.log(prof / 3 + 1, 10)
+                            local uniqueIdBytes = wordBytes(
+                                (xsb and isLocalPlayer(receiverEntityId)) and world.entityUniqueId(receiverEntityId)
+                                    or player.uniqueId()
+                            )
+
+                            if langColor == nil then
+                                local hexDigits =
+                                    { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F" }
+                                local randSource = sb.makeRandomSource()
+                                local hexMin = 1
+
+                                --not sure if there's an cleaner way to do this
+                                randSource:init(math.tointeger(byteLC + wordBytes("Red One")))
+                                local rNumR = hexDigits[randSource:randInt(hexMin, 16)]
+                                randSource:init(math.tointeger(byteLC + wordBytes("Green Two")))
+                                local rNumG = hexDigits[randSource:randInt(hexMin, 16)]
+                                randSource:init(math.tointeger(byteLC + wordBytes("Blue Three")))
+                                local rNumB = hexDigits[randSource:randInt(hexMin, 16)]
+                                randSource:init(math.tointeger(byteLC + wordBytes("Red Four")))
+                                local rNumR2 = hexDigits[randSource:randInt(hexMin, 16)]
+                                randSource:init(math.tointeger(byteLC + wordBytes("Green Five")))
+                                local rNumG2 = hexDigits[randSource:randInt(hexMin, 16)]
+                                randSource:init(math.tointeger(byteLC + wordBytes("Blue Six")))
+                                local rNumB2 = hexDigits[randSource:randInt(hexMin, 16)]
+                                langColor = "#" .. rNumR .. rNumG .. rNumB .. rNumR2 .. rNumG2 .. rNumB2
+                            end
+
+                            while iCount <= #str do
+                                char = str:sub(iCount, iCount)
+                                -- FezzedOne: Got rid of hardcoded assumption that language keys are two characters long.
+                                if char == "[" and str:find(iCount, "]") ~= nil then
+                                    local closingBracket = str:find("]", iCount)
+                                    returnStr = returnStr .. char .. str:sub(iCount + 1, closingBracket)
+                                    iCount = closingBracket + 1
+                                elseif char == " " and not wordBuffer:match("%a") and #wordBuffer > 0 then
+                                    returnStr = returnStr .. " " .. wordBuffer
+                                    wordBuffer = ""
+                                elseif char ~= "'" and char:match("[%s%p]") then
+                                    if #wordBuffer > 0 then
+                                        local wordLength = #wordBuffer
+                                        local byteWord = wordBytes(wordBuffer)
+                                        randSource:init(math.tointeger(uniqueIdBytes + byteLC + byteWord))
+                                        local wordRoll = randSource:randInt(1, 100)
+                                        if
+                                            effProf < 5
+                                            or (wordRoll + (wordLength ^ 2 / (math.max(1, effProf - 50) / 5)) - 10)
+                                                > effProf
+                                        then
+                                            wordBuffer = langWordRep(trim(wordBuffer), effProf, byteLC)
+                                            wordBuffer = "^" .. langColor .. ";" .. wordBuffer .. "^" .. msgColor .. ";"
+                                            rCount = rCount + 1
                                         end
-                                        if langProf == nil then
-                                            local receiverIsLocal = isLocalPlayer(receiverEntityId)
-                                            local newLang
-                                            if xsb and receiverIsLocal then
-                                                newLang = world
-                                                    .sendEntityMessage(receiverEntityId, "hasLangKey", langKey)
-                                                    :result() or nil
-                                            else
-                                                newLang = player.getItemWithParameter("langKey", langKey) or nil
-                                            end
-                                            if newLang then
-                                                langColor = newLang["parameters"]["color"]
-                                                local hasItem
-                                                if xsb and receiverIsLocal then
-                                                    hasItem = world
-                                                        .sendEntityMessage(receiverEntityId, "langKeyCount", newLang)
-                                                        :result()
-                                                else
-                                                    hasItem = player.hasCountOfItem(newLang, true)
-                                                end
+                                    end
+                                    returnStr = returnStr .. wordBuffer .. char
+                                    wordBuffer = ""
+                                else
+                                    wordBuffer = wordBuffer .. char
+                                end
+                                iCount = iCount + 1
+                            end
 
-                                                if hasItem then
-                                                    langProf = hasItem * 10
+                            if returnStr:match("%s", #returnStr) then returnStr = returnStr:sub(0, #returnStr - 1) end
+
+                            randSource:init()
+                            return returnStr
+                        end
+
+                        local colorTable = { --transparency is an options here, but it makes things hard to read
+                            [-4] = "#555",
+                            [-3] = "#777",
+                            [-2] = "#999",
+                            [-1] = "#bbb",
+                            [0] = "#ddd",
+                            [1] = "#fff",
+                            [2] = "#daa",
+                            [3] = "#d66",
+                            [4] = "#d00",
+                        }
+
+                        local function colorWithin(str, char, color, prevColor)
+                            local colorOn = false
+                            local charBuffer = ""
+                            for i in str:gmatch(".") do
+                                if i == char then
+                                    if colorOn == false then
+                                        charBuffer = charBuffer .. "^" .. color .. ";"
+                                        colorOn = true
+                                    else
+                                        charBuffer = charBuffer .. "^" .. prevColor .. ";"
+                                        colorOn = false
+                                    end
+                                else
+                                    --put this outside the if statement to make the characters appear as well as colors
+                                    charBuffer = charBuffer .. i
+                                end
+                            end
+                            -- print("Charbuffer is " .. charBuffer)
+                            return charBuffer
+                        end
+
+                        local function cleanDoubleSpaces(str)
+                            --run a loop with the string, ignore codes (^whatever;), then remove more than one space in a row
+                            local cleanStr = ""
+                            local iCount = 1
+                            local prevChar = ""
+                            local prevColor = ""
+
+                            while iCount <= #str do
+                                local char = str:sub(iCount, iCount)
+                                local nextSemi = 0
+
+                                if char == "^" then
+                                    nextSemi = str:find(";", iCount)
+
+                                    if nextSemi ~= nil then
+                                        local colorCode = str:sub(iCount, nextSemi)
+                                        if colorCode ~= prevColor then cleanStr = cleanStr .. colorCode end
+                                        prevColor = colorCode
+                                        iCount = nextSemi
+                                    end
+                                elseif char ~= " " or prevChar ~= " " then
+                                    cleanStr = cleanStr .. char
+                                    prevChar = char
+                                end
+                                iCount = iCount + 1
+                            end
+                            cleanStr = cleanStr:gsub("%{ ", "{")
+                            cleanStr = cleanStr:gsub(" %}", "}")
+                            return cleanStr
+                        end
+
+                        --do visual formatting here.
+                        --for dialogue (NOT sounds), start degrading the quality of the message at 50% of the quotes's radius
+                        local tableStr = ""
+                        local prevStr = ""
+                        local quoteCombo = ""
+                        local soundCombo = ""
+                        local prevType = "action"
+                        local quoteOpen = false
+                        local soundOpen = false
+                        local hasValids = false
+                        local chunkStr
+                        local chunkType
+                        local langBank = {} --populate with languages in inventory when you find them
+                        local prevLang = getDefaultLang() --either the player's default language, or !!
+
+                        if maxRad ~= -1 and (messageDistance > maxRad and validSum == 0) then
+                            message.text = ""
+                        else
+                            chunkType = nil
+
+                            local prevChunk = ""
+                            local repeatFlag = false
+                            table.insert(textTable, {
+                                text = "",
+                                radius = "0",
+                                type = "bad",
+                                langKey = ":(",
+                                valid = false,
+                                msgQuality = 0,
+                            })
+
+                            for k, v in pairs(textTable) do
+                                if v["hasLOS"] == false and chunkType == "action" then v["valid"] = false end
+                                if v["valid"] then hasValids = true end
+                            end
+                            for k, v in pairs(textTable) do
+                                if v["radius"] == -1 or v["isRadio"] == true then v["valid"] = true end
+
+                                chunkStr = v["text"]
+                                chunkType = v["type"]
+                                local langKey = v["langKey"]
+                                if
+                                    v["valid"] == true
+                                    or (
+                                        chunkType == "quote"
+                                        and (
+                                            (k > 1 and textTable[k - 1]["type"] == "quote")
+                                            or (k < #textTable and textTable[k + 1]["type"] == "quote")
+                                        )
+                                    )
+                                then --check if this is surrounded by quotes
+                                    v["valid"] = true --this should be set to true in here, since everything in this block should show up on the screen
+                                    -- remember, noiserad is a const and radius is for the message
+
+                                    local colorOverride = chunkStr:find("%^%#") ~= nil --don't touch colors if this is true
+                                    local actionColor = "#fff" --white for non sound based chunks
+                                    local msgColor = "#fff" --white for non sound based chunks
+                                    --disguise unheard stuff
+                                    if chunkType == "sound" then
+                                        if not colorOverride then
+                                            msgColor = colorTable[volTable[v["radius"]]]
+                                            chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                        end
+                                    elseif chunkType == "quote" then
+                                        msgColor = colorTable[volTable[v["radius"]]]
+
+                                        if chunkType == "quote" and langKey ~= "!!" then
+                                            local langProf, langColor
+                                            if langBank[langKey] ~= nil then
+                                                langProf = langBank[langKey]["prof"]
+                                                langColor = langBank[langKey]["color"]
+                                            end
+                                            if langProf == nil then
+                                                local receiverIsLocal = isLocalPlayer(receiverEntityId)
+                                                local newLang
+                                                if xsb and receiverIsLocal then
+                                                    newLang = world
+                                                        .sendEntityMessage(receiverEntityId, "hasLangKey", langKey)
+                                                        :result() or nil
+                                                else
+                                                    newLang = player.getItemWithParameter("langKey", langKey) or nil
+                                                end
+                                                if newLang then
+                                                    langColor = newLang["parameters"]["color"]
+                                                    local hasItem
+                                                    if xsb and receiverIsLocal then
+                                                        hasItem = world
+                                                            .sendEntityMessage(receiverEntityId, "langKeyCount", newLang)
+                                                            :result()
+                                                    else
+                                                        hasItem = player.hasCountOfItem(newLang, true)
+                                                    end
+
+                                                    if hasItem then
+                                                        langProf = hasItem * 10
+                                                    else
+                                                        langProf = 0
+                                                    end
+                                                    langBank[langKey] = {
+                                                        prof = langProf,
+                                                        color = langColor,
+                                                    }
                                                 else
                                                     langProf = 0
                                                 end
-                                                langBank[langKey] = {
-                                                    prof = langProf,
-                                                    color = langColor,
-                                                }
-                                            else
-                                                langProf = 0
+                                            end
+
+                                            if langProf < 100 then
+                                                --scramble the word
+                                                chunkStr =
+                                                    langScramble(trim(chunkStr), langProf, langKey, msgColor, langColor)
                                             end
                                         end
+                                        --check message quality
+                                        if v["msgQuality"] < 100 and not v["isRadio"] and chunkType == "quote" then
+                                            chunkStr = degradeMessage(trim(chunkStr), v["msgQuality"])
+                                        end
 
-                                        if langProf < 100 then
-                                            --scramble the word
-                                            chunkStr =
-                                                langScramble(trim(chunkStr), langProf, langKey, msgColor, langColor)
+                                        if not colorOverride then
+                                            chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                        end
+
+                                        --add in languagee indicator
+                                        if langKey ~= prevLang then
+                                            chunkStr = "^#fff;[" .. langKey .. "]^" .. msgColor .. "; " .. chunkStr
+                                            prevLang = langKey
                                         end
                                     end
-                                    --check message quality
-                                    if v["msgQuality"] < 100 and not v["isRadio"] and chunkType == "quote" then
-                                        chunkStr = degradeMessage(trim(chunkStr), v["msgQuality"])
-                                    end
+                                    chunkStr = chunkStr:gsub("%^%#fff%;%^%#fff;", "^#fff;")
+                                    chunkStr = chunkStr:gsub("%^" .. msgColor .. ";%^#fff;", "^#fff;")
+                                    chunkStr = chunkStr:gsub(
+                                        "%^" .. msgColor .. ";%^" .. msgColor .. ";",
+                                        "^" .. msgColor .. ";"
+                                    )
 
-                                    if not colorOverride then
-                                        chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                    --recolors certain things for emphasis
+                                    if chunkType ~= "action" then --allow asterisks to stay in actions
+                                        chunkStr = colorWithin(chunkStr, "*", "#fe7", msgColor) --yellow
                                     end
-
-                                    --add in languagee indicator
-                                    if langKey ~= prevLang then
-                                        chunkStr = "^#fff;[" .. langKey .. "]^" .. msgColor .. "; " .. chunkStr
-                                        prevLang = langKey
-                                    end
+                                    -- FezzedOne: This now uses backticks.
+                                    chunkStr = colorWithin(chunkStr, "`", "#d80", msgColor) --orange
+                                elseif chunkType == "quote" and hasValids and prevType ~= "quote" then
+                                    chunkStr = "Says something."
+                                    v["valid"] = true
+                                    chunkType = "action"
                                 end
-                                chunkStr = chunkStr:gsub("%^%#fff%;%^%#fff;", "^#fff;")
-                                chunkStr = chunkStr:gsub("%^" .. msgColor .. ";%^#fff;", "^#fff;")
-                                chunkStr =
-                                    chunkStr:gsub("%^" .. msgColor .. ";%^" .. msgColor .. ";", "^" .. msgColor .. ";")
 
-                                --recolors certain things for emphasis
-                                if chunkType ~= "action" then --allow asterisks to stay in actions
-                                    chunkStr = colorWithin(chunkStr, "*", "#fe7", msgColor) --yellow
+                                --after check, this puts formatted chunks in
+                                if chunkType ~= "quote" and prevType == "quote" then
+                                    local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
+
+                                    if not checkCombo:match("[%w%d]") then
+                                        if prevStr ~= "Says something." then
+                                            quoteCombo = "Says something."
+                                        else
+                                            quoteCombo = ""
+                                        end
+                                        prevStr = quoteCombo
+                                    end
+
+                                    quoteCombo = '"' .. quoteCombo .. '"'
+                                    tableStr = tableStr .. " " .. quoteCombo
+                                    quoteCombo = ""
                                 end
-                                -- FezzedOne: This now uses backticks.
-                                chunkStr = colorWithin(chunkStr, "`", "#d80", msgColor) --orange
-                            elseif chunkType == "quote" and hasValids and prevType ~= "quote" then
-                                chunkStr = "Says something."
-                                v["valid"] = true
-                                chunkType = "action"
-                            end
+                                if chunkType ~= "sound" and prevType == "sound" then
+                                    if soundCombo:match("[%w%d]") then
+                                        soundCombo = "<" .. soundCombo .. ">"
+                                        tableStr = tableStr .. " " .. soundCombo
+                                    end
+                                    soundCombo = ""
+                                end
 
-                            --after check, this puts formatted chunks in
-                            if chunkType ~= "quote" and prevType == "quote" then
-                                local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
-
-                                if not checkCombo:match("[%w%d]") then
-                                    if prevStr ~= "Says something." then
-                                        quoteCombo = "Says something."
+                                if v["valid"] and chunkType == "quote" then
+                                    if quoteCombo:sub(#quoteCombo):match("%p") then
+                                        --this adds the space after a quote
+                                        quoteCombo = quoteCombo .. " " .. chunkStr
                                     else
-                                        quoteCombo = ""
+                                        quoteCombo = quoteCombo .. chunkStr
                                     end
-                                    prevStr = quoteCombo
+                                elseif v["valid"] and chunkType == "sound" then
+                                    if soundCombo:sub(#soundCombo):match("%p") then
+                                        --this adds the space after a quote
+                                        soundCombo = soundCombo .. " " .. chunkStr
+                                    else
+                                        soundCombo = soundCombo .. chunkStr
+                                    end
+                                elseif v["valid"] then --everything that isn't a sound or a quote goes here
+                                    tableStr = tableStr .. " " .. chunkStr
+                                    prevStr = chunkStr
                                 end
 
-                                quoteCombo = '"' .. quoteCombo .. '"'
-                                tableStr = tableStr .. " " .. quoteCombo
-                                quoteCombo = ""
+                                prevType = chunkType
                             end
-                            if chunkType ~= "sound" and prevType == "sound" then
-                                if soundCombo:match("[%w%d]") then
-                                    soundCombo = "<" .. soundCombo .. ">"
-                                    tableStr = tableStr .. " " .. soundCombo
-                                end
-                                soundCombo = ""
-                            end
+                            tableStr = cleanDoubleSpaces(tableStr) --removes double spaces, ignores colors
+                            tableStr = tableStr:gsub(' "%s', ' "')
+                            tableStr = tableStr:gsub("}{", "...") --for multiple radios
+                            tableStr = trim(tableStr)
 
-                            if v["valid"] and chunkType == "quote" then
-                                if quoteCombo:sub(#quoteCombo):match("%p") then
-                                    --this adds the space after a quote
-                                    quoteCombo = quoteCombo .. " " .. chunkStr
-                                else
-                                    quoteCombo = quoteCombo .. chunkStr
-                                end
-                            elseif v["valid"] and chunkType == "sound" then
-                                if soundCombo:sub(#soundCombo):match("%p") then
-                                    --this adds the space after a quote
-                                    soundCombo = soundCombo .. " " .. chunkStr
-                                else
-                                    soundCombo = soundCombo .. chunkStr
-                                end
-                            elseif v["valid"] then --everything that isn't a sound or a quote goes here
-                                tableStr = tableStr .. " " .. chunkStr
-                                prevStr = chunkStr
-                            end
-
-                            prevType = chunkType
+                            message.text = tableStr
                         end
-                        tableStr = cleanDoubleSpaces(tableStr) --removes double spaces, ignores colors
-                        tableStr = tableStr:gsub(' "%s', ' "')
-                        tableStr = tableStr:gsub("}{", "...") --for multiple radios
-                        tableStr = trim(tableStr)
+                    end
 
-                        message.text = tableStr
+                    message.portrait = message.portrait and message.portrait ~= "" and message.portrait
+                        or message.connection
+                    if copiedMessage then
+                        message.processed = true
+                        world.sendEntityMessage(receiverEntityId, "scc_add_message", message)
                     end
                 end
 
-                message.portrait = message.portrait and message.portrait ~= "" and message.portrait
-                    or message.connection
-                if copiedMessage then
-                    message.processed = true
-                    world.sendEntityMessage(receiverEntityId, "scc_add_message", message)
+                if xsb and message.contentIsText then
+                    for _, pId in ipairs(ownPlayers) do
+                        handleMessage(pId, deepCopy(message))
+                    end
+                    message.text = ""
+                elseif message.contentIsText then
+                    handleMessage(receiverEntityId, deepCopy(message))
+                    message.text = ""
+                else
+                    handleMessage(receiverEntityId)
                 end
-            end
-
-            if xsb and message.contentIsText then
-                for _, pId in ipairs(ownPlayers) do
-                    handleMessage(pId, deepCopy(message))
-                end
-                message.text = ""
-            elseif message.contentIsText then
-                handleMessage(receiverEntityId, deepCopy(message))
-                message.text = ""
-            else
-                handleMessage(receiverEntityId)
             end
         end
+
+        return message
     end
 
-    return message
+    local status, messageOrError = pcall(messageFormatter, deepCopy(message))
+    if status then
+        return messageOrError
+    else
+        sb.logWarn(
+            "[DynamicProxChat] Error occurred while formatting proximity message: %s\n  Message data: %s",
+            messageOrError,
+            message
+        )
+        return message
+    end
 end
 
 function dynamicprox:onReceiveMessage(message) --here for logging the message you receive, just in case you wanted to save it or something

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1390,6 +1390,6 @@ end
 
 function dynamicprox:onReceiveMessage(message) --here for logging the message you receive, just in case you wanted to save it or something
     if message.connection ~= 0 and (message.mode == "Prox" or message.mode == "ProxSecondary") then
-        sb.logInfo("Chat: <%s> %s", message.nickname, message.text)
+        sb.logInfo("Chat: <%s> %s", message.nickname:gsub("%^[^^;];", ""), message.text:gsub("%^[^^;];", ""))
     end
 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -385,7 +385,6 @@ function dynamicprox:onSendMessage(data)
                             else
                                 -- FezzedOne: Fixed issue where special characters weren't escaped before being passed as a Lua pattern.
                                 langKey = rawText:sub(iCount + 1, langEnd - 1)
-                                sb.logInfo("langKey = '%s'", langKey)
                                 langKey = langKey:gsub("[%(%)%.%%%+%-%*%?%[%^%$]", function(s) return "%" .. s end)
                             end
                             local upperKey = langKey:upper()

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -731,7 +731,8 @@ function dynamicprox:formatIncomingMessage(message)
                         local fStart, fEnd = rawText:find("%d+|", cInd)
 
                         if fStart ~= nil and fEnd ~= nil then
-                            local timeNum = message.time:gsub("%D", "")
+                            -- FezzedOne: Fixed nil dereference bug here. Not all messages have a time!
+                            local timeNum = tostring(math.floor(os.time()))
                             local mixNum = tonumber(timeNum .. math.abs(authorEntityId))
                             randSource:init(mixNum)
                             local numMax = rawSub(fStart, fEnd - 1):gsub("%D", "")

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1,1201 +1,1236 @@
-require "/interface/scripted/starcustomchat/plugin.lua"
+require("/interface/scripted/starcustomchat/plugin.lua")
 
 dynamicprox = PluginClass:new({
-  name = "dynamicprox"
+    name = "dynamicprox",
 })
 
-function dynamicprox:init()
-  self:_loadConfig()
-end
+function dynamicprox:init() self:_loadConfig() end
 
 function dynamicprox:addCustomCommandPreview(availableCommands, substr)
-  if string.find("/newlangitem", substr, nil, true) then
-    table.insert(availableCommands, {
-      name = "/newlangitem",
-      description = "commands.newlangitem.desc",
-      data = "/newlangitem",
-      color = nil
-    })
-  elseif string.find("/addtypo", substr, nil, true) then
-    table.insert(availableCommands, {
-      name = "/addtypo",
-      description = "commands.addtypo.desc",
-      data = "/addtypo"
-    })
-  elseif string.find("/removetypo", substr, nil, true) then
-    table.insert(availableCommands, {
-      name = "/removetypo",
-      description = "commands.removetypo.desc",
-      data = "/removetypo"
-    })
-  elseif string.find("/toggletypos", substr, nil, true) then
-    table.insert(availableCommands, {
-      name = "/toggletypos",
-      description = "commands.toggletypos.desc",
-      data = "/toggletypos"
-    })
-  elseif string.find("/checktypo", substr, nil, true) then
-    table.insert(availableCommands, {
-      name = "/checktypo",
-      description = "commands.checktypo.desc",
-      data = "/checktypo"
-    })
+    if string.find("/newlangitem", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/newlangitem",
+            description = "commands.newlangitem.desc",
+            data = "/newlangitem",
+            color = nil,
+        })
+    elseif string.find("/addtypo", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/addtypo",
+            description = "commands.addtypo.desc",
+            data = "/addtypo",
+        })
+    elseif string.find("/removetypo", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/removetypo",
+            description = "commands.removetypo.desc",
+            data = "/removetypo",
+        })
+    elseif string.find("/toggletypos", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/toggletypos",
+            description = "commands.toggletypos.desc",
+            data = "/toggletypos",
+        })
+    elseif string.find("/checktypo", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/checktypo",
+            description = "commands.checktypo.desc",
+            data = "/checktypo",
+        })
     --this one is broken, not sure why
-  elseif string.find("/showtypos", substr, nil, true) then
-    table.insert(availableCommands, {
-      name = "/showtypos",
-      description = "commands.showtypos.desc",
-      data = "/showtypos"
-    })
-  end
+    elseif string.find("/showtypos", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/showtypos",
+            description = "commands.showtypos.desc",
+            data = "/showtypos",
+        })
+    end
 end
 
 local function checktypo(toggle)
-  local typoTable = player.getProperty("typos", {})
-  local typoStatus
+    local typoTable = player.getProperty("typos", {})
+    local typoStatus
 
-  if typoTable["typosActive"] == true then
-    if toggle then
-      typoTable["typosActive"] = false
-      typoStatus = "off"
+    if typoTable["typosActive"] == true then
+        if toggle then
+            typoTable["typosActive"] = false
+            typoStatus = "off"
+        else
+            typoStatus = "on"
+        end
     else
-      typoStatus = "on"
+        if toggle then
+            typoTable["typosActive"] = true
+            typoStatus = "on"
+        else
+            typoStatus = "off"
+        end
     end
-  else
-    if toggle then
-      typoTable["typosActive"] = true
-      typoStatus = "on"
-    else
-      typoStatus = "off"
-    end
-  end
-  player.setProperty("typos", typoTable)
-  return "Typo correction is " .. typoStatus
+    player.setProperty("typos", typoTable)
+    return "Typo correction is " .. typoStatus
 end
 
 local function splitStr(inputstr, sep)
-  if sep == nil then
-    sep = "%s"
-  end
-  local t = {}
-  for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
-    table.insert(t, str)
-  end
-  return t
+    if sep == nil then sep = "%s" end
+    local t = {}
+    for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
+        table.insert(t, str)
+    end
+    return t
 end
 
 local function getDefaultLang()
-  local langItem = player.getItemWithParameter("defaultLang", true) --checks for an item with the "defaultLang" parameter
-  local defaultKey
-  if langItem == nil then
-    defaultKey = "!!"
-  else
-    defaultKey = langItem['parameters']['langKey'] or "!!"
-  end
-  return defaultKey
+    local langItem = player.getItemWithParameter("defaultLang", true) --checks for an item with the "defaultLang" parameter
+    local defaultKey
+    if langItem == nil then
+        defaultKey = "!!"
+    else
+        defaultKey = langItem["parameters"]["langKey"] or "!!"
+    end
+    return defaultKey
 end
 
 --this messagehandler function runs if the chat preview exists
 function dynamicprox:registerMessageHandlers(shared) --look at this function in irden chat's editchat thing
-  starcustomchat.utils.setMessageHandler("/showtypos", function(_, _, data)
-    local typoTable = player.getProperty("typos", {})
-    if typoTable == nil then
-      return "You have no corrections or typos saved. Use /addtypo to make one."
-    end
+    starcustomchat.utils.setMessageHandler("/showtypos", function(_, _, data)
+        local typoTable = player.getProperty("typos", {})
+        if typoTable == nil then return "You have no corrections or typos saved. Use /addtypo to make one." end
 
-    local rtStr = "Typos and corrections:^#2ee;"
-    local tyTableLen = 0
-    local typosActive = "off"
-    for k, v in pairs(typoTable) do
-      if k ~= "typosActive" then
-        rtStr = rtStr .. " {" .. k .. " -> " .. v .. "}"
-        tyTableLen = tyTableLen + 1
-      elseif v then
-        typosActive = "on"
-      end
-    end
-    rtStr = rtStr .. "^reset;. Typo correction is " .. typosActive .. "."
+        local rtStr = "Typos and corrections:^#2ee;"
+        local tyTableLen = 0
+        local typosActive = "off"
+        for k, v in pairs(typoTable) do
+            if k ~= "typosActive" then
+                rtStr = rtStr .. " {" .. k .. " -> " .. v .. "}"
+                tyTableLen = tyTableLen + 1
+            elseif v then
+                typosActive = "on"
+            end
+        end
+        rtStr = rtStr .. "^reset;. Typo correction is " .. typosActive .. "."
 
-    if tyTableLen == 0 then
-      rtStr = "You have no corrections or typos saved. Use /addtypo to make one."
-    end
-    return rtStr
-  end)
-  starcustomchat.utils.setMessageHandler("/checktypo", function(_, _, data)
-    return checktypo(false)
-  end)
-  starcustomchat.utils.setMessageHandler("/toggletypos", function(_, _, data)
-    return checktypo(true)
-  end)
-  starcustomchat.utils.setMessageHandler("/addtypo", function(_, _, data)
-    --add a typo correction to the typos table in player data, or replace it if it already exists
-    -- local typo, correction = chat.parseArguments(data)
-    local splitArgs = splitStr(data, " ")
-    local typo, correction = splitArgs[1], splitArgs[2]
+        if tyTableLen == 0 then rtStr = "You have no corrections or typos saved. Use /addtypo to make one." end
+        return rtStr
+    end)
+    starcustomchat.utils.setMessageHandler("/checktypo", function(_, _, data) return checktypo(false) end)
+    starcustomchat.utils.setMessageHandler("/toggletypos", function(_, _, data) return checktypo(true) end)
+    starcustomchat.utils.setMessageHandler("/addtypo", function(_, _, data)
+        --add a typo correction to the typos table in player data, or replace it if it already exists
+        -- local typo, correction = chat.parseArguments(data)
+        local splitArgs = splitStr(data, " ")
+        local typo, correction = splitArgs[1], splitArgs[2]
 
-    if typo == nil or correction == nil then
-      return "Missing arguments for /addtypo, need {typo, correction}"
-    end
-    local typoTable = player.getProperty("typos", {})
+        if typo == nil or correction == nil then return "Missing arguments for /addtypo, need {typo, correction}" end
+        local typoTable = player.getProperty("typos", {})
 
-    typoTable[typo] = correction
-    player.setProperty("typos", typoTable)
-    return "Typo \"" .. typo .. "\" added as \"" .. correction .. "\"."
-  end)
-  starcustomchat.utils.setMessageHandler("/removetypo", function(_, _, data)
-    --add a typo correction to the typos table in player data, or replace it if it already exists
-    -- local typo = chat.parseArguments(data)
-    local typo = splitStr(data, " ")[1]
-    local typoTable = player.getProperty("typos", false)
+        typoTable[typo] = correction
+        player.setProperty("typos", typoTable)
+        return 'Typo "' .. typo .. '" added as "' .. correction .. '".'
+    end)
+    starcustomchat.utils.setMessageHandler("/removetypo", function(_, _, data)
+        --add a typo correction to the typos table in player data, or replace it if it already exists
+        -- local typo = chat.parseArguments(data)
+        local typo = splitStr(data, " ")[1]
+        local typoTable = player.getProperty("typos", false)
 
-    if typo == nil then
-      return "Missing arguments for /removetypo, need {typo}"
-    end
+        if typo == nil then return "Missing arguments for /removetypo, need {typo}" end
 
-    if typoTable then
-      typoTable[typo] = nil
-      player.setProperty("typos", typoTable)
-    end
-    return "Typo \"" .. typo .. "\" removed."
-  end)
+        if typoTable then
+            typoTable[typo] = nil
+            player.setProperty("typos", typoTable)
+        end
+        return 'Typo "' .. typo .. '" removed.'
+    end)
 
-  starcustomchat.utils.setMessageHandler("/newlangitem", function(_, _, data)
-    local splitArgs = splitStr(data, " ")
-    local langName, langKey, langLevel, isDefault, color = (splitArgs[1] or nil), (splitArgs[2] or nil),
-        (tonumber(splitArgs[3]) or 10),
-        (splitArgs[4] or nil), (splitArgs[5] or nil)
+    starcustomchat.utils.setMessageHandler("/newlangitem", function(_, _, data)
+        local splitArgs = splitStr(data, " ")
+        local langName, langKey, langLevel, isDefault, color =
+            (splitArgs[1] or nil),
+            (splitArgs[2] or nil),
+            (tonumber(splitArgs[3]) or 10),
+            (splitArgs[4] or nil),
+            (splitArgs[5] or nil)
 
-    if langKey == nil or langName == nil then
-      return "Missing arguments for /newlangitem, need {name, code, count, automatic, [hex color]}"
-    end
-    if isDefault == nil then
-      isDefault = false
-    end
+        if langKey == nil or langName == nil then
+            return "Missing arguments for /newlangitem, need {name, code, count, automatic, [hex color]}"
+        end
+        if isDefault == nil then isDefault = false end
 
-    if color ~= nil then
-      if not color:match("#") then
-        color = "#" .. color
-      end
-      if #color > 7 then
-        color = color:sub(1, 7)
-      end
-    end
-    langKey = langKey:upper()
-    langKey = langKey:gsub("[%[%]]", "")
+        if color ~= nil then
+            if not color:match("#") then color = "#" .. color end
+            if #color > 7 then color = color:sub(1, 7) end
+        end
+        langKey = langKey:upper()
+        langKey = langKey:gsub("[%[%]]", "")
 
-    langLevel = math.max(1, math.min(langLevel, 10))
-    local itemName = "inferiorbrain"
-    local itemDesc = "Allows the user to understand " .. langName .. " [" .. langKey .. "]"
-    local shortDesc = "[" .. langKey .. "] " .. langName .. " Aptitude"
-    local itemRarity = "Uncommon"
-    local itemImage = "inferiorbrain.png"
+        langLevel = math.max(1, math.min(langLevel, 10))
+        local itemName = "inferiorbrain"
+        local itemDesc = "Allows the user to understand " .. langName .. " [" .. langKey .. "]"
+        local shortDesc = "[" .. langKey .. "] " .. langName .. " Aptitude"
+        local itemRarity = "Uncommon"
+        local itemImage = "inferiorbrain.png"
 
-    if isDefault ~= nil and (isDefault == "true") then
-      isDefault = true
-      itemRarity = "Rare"
-      itemName = "brain"
-      itemDesc = "!Default, will automatically apply! " .. itemDesc
-      itemImage = "brain.png"
-    else
-      isDefault = false
-    end
+        if isDefault ~= nil and (isDefault == "true") then
+            isDefault = true
+            itemRarity = "Rare"
+            itemName = "brain"
+            itemDesc = "!Default, will automatically apply! " .. itemDesc
+            itemImage = "brain.png"
+        else
+            isDefault = false
+        end
 
-    local itemData = {
-      name = itemName,
-      count = langLevel,
-      parameters = {
-        inventoryIcon = itemImage,
-        description = itemDesc,
-        rarity = itemRarity,
-        maxStack = 10,
-        shortdescription = shortDesc,
-        langKey = langKey,
-        defaultLang = isDefault,
-        color = color
-      }
-    }
+        local itemData = {
+            name = itemName,
+            count = langLevel,
+            parameters = {
+                inventoryIcon = itemImage,
+                description = itemDesc,
+                rarity = itemRarity,
+                maxStack = 10,
+                shortdescription = shortDesc,
+                langKey = langKey,
+                defaultLang = isDefault,
+                color = color,
+            },
+        }
 
-    player.giveItem(itemData)
-    return "Language " .. langName .. " added, use [" .. langKey .. "] to use it."
-  end)
+        player.giveItem(itemData)
+        return "Language " .. langName .. " added, use [" .. langKey .. "] to use it."
+    end)
 end
 
 function dynamicprox:onSendMessage(data)
-  --think about running this in local to allow players without the mod to still see messages
+    --think about running this in local to allow players without the mod to still see messages
 
-  if data.mode == "Prox" then
-    -- data.time = systemTime() this is where i'd add time if i wanted it
-    data.proxRadius = self.proxRadius
-    local function sendMessageToPlayers()
-      local position = player.id() and world.entityPosition(player.id())
+    if data.mode == "Prox" then
+        -- data.time = systemTime() this is where i'd add time if i wanted it
+        data.proxRadius = self.proxRadius
+        local function sendMessageToPlayers()
+            local position = player.id() and world.entityPosition(player.id())
 
-      if position then
-        local estRad = data.proxRadius
-        local rawText = data.text
-        local sum = 0
-        local parenSum = 0
-        local iCount = 1
-        local globalFlag = false
-        local hasNoise = false
-        local defaultKey = getDefaultLang()
-        data.defaultLang = defaultKey
-        local typoTable = player.getProperty("typos", {})
-        local typoVar = typoTable["typosActive"]
-        if typoVar then
-          local newText = ""
-          local wordBuffer = ""
-          for i in (rawText .. " "):gmatch(".") do
-            if i:match("[%s%p]") and i ~= "[" and i ~= "]" then
-              if typoTable[wordBuffer] ~= nil then
-                newText = newText .. typoTable[wordBuffer] .. i
+            -- FezzedOne: Global OOC chat.
+            local globalOocStrings = {}
+            data.text = data.text:gsub("%(%(%((.-)%)%)%)", function(s)
+                table.insert(globalOocStrings, s)
+                return ""
+            end)
 
-                wordBuffer = ""
-              else
-                newText = newText .. wordBuffer .. i
-              end
-              wordBuffer = ""
-            else
-              wordBuffer = wordBuffer .. i
+            local globalStrings = {}
+            -- FezzedOne: Global actions and radio. Does not support IC language tags.
+            data.text = data.text:gsub("[{<][{<](.-)[}>][}>]", function(s)
+                table.insert(globalStrings, s)
+                return ""
+            end)
+
+            if position then
+                local estRad = data.proxRadius
+                local rawText = data.text
+                local sum = 0
+                local parenSum = 0
+                local iCount = 1
+                local globalFlag = false
+                local hasNoise = false
+                local defaultKey = getDefaultLang()
+                data.defaultLang = defaultKey
+                local typoTable = player.getProperty("typos", {})
+                local typoVar = typoTable["typosActive"]
+                if typoVar then
+                    local newText = ""
+                    local wordBuffer = ""
+                    for i in (rawText .. " "):gmatch(".") do
+                        if i:match("[%s%p]") and i ~= "[" and i ~= "]" then
+                            if typoTable[wordBuffer] ~= nil then
+                                newText = newText .. typoTable[wordBuffer] .. i
+
+                                wordBuffer = ""
+                            else
+                                newText = newText .. wordBuffer .. i
+                            end
+                            wordBuffer = ""
+                        else
+                            wordBuffer = wordBuffer .. i
+                        end
+                    end
+                    rawText = newText:sub(1, #newText - 1)
+                end
+                while iCount <= #rawText and not globalFlag do
+                    if parenSum == 3 then globalFlag = true end
+
+                    local i = rawText:sub(iCount, iCount)
+                    local langEnd = rawText:find("]", iCount)
+                    if i == "+" then
+                        sum = sum + 1
+                    elseif i == "(" then
+                        parenSum = parenSum + 1
+                    elseif i == "{" and rawText:find("}", iCount) ~= nil then
+                        globalFlag = true
+                    elseif i == "[" and langEnd ~= nil then --use this flag to check for default languages. A string without any noise won't have any language support
+                        local langKey
+                        if rawText:sub(iCount, langEnd) == "[]" then --checking for []
+                            langKey = defaultKey
+                            rawText = rawText:gsub("%[%]", "[" .. defaultKey .. "]")
+                        else
+                            langKey = rawText:sub(iCount + 1, langEnd - 1)
+                        end
+                        local upperKey = langKey:upper()
+
+                        local langItem = player.getItemWithParameter("langKey", upperKey)
+
+                        if langItem == nil and upperKey ~= "!!" then
+                            rawText = rawText:gsub("%[" .. langKey, "[" .. defaultKey)
+                        end
+                    else
+                        parenSum = 0
+                    end
+                    iCount = iCount + 1
+                end
+                data.content = rawText
+                data.text = ""
+                if parenSum == 2 or globalFlag then
+                    estRad = estRad * 2
+                elseif sum > 3 then
+                    estRad = estRad * 1.5
+                else
+                    estRad = estRad + (estRad * 0.25 + (3 * sum))
+                end
+
+                --estrad should be pretty close to actual radius
+
+                --this is where i'd change players if needed
+                local players = world.playerQuery(position, estRad, {
+                    boundMode = "position",
+                })
+
+                -- if xsb then -- FezzedOne: On xStarbound, filter out local secondaries to avoid showing duplicate sent messages.
+                --     local localPlayers = world.ownPlayers()
+                --     local primaryPlayer = world.primaryPlayer()
+                --     for i = #localPlayers, 1, -1 do
+                --         if localPlayers[i] == primaryPlayer then
+                --             table.remove(localPlayers, i)
+                --             break
+                --         end
+                --     end
+                --     for i = #players, 1, -1 do
+                --         for j = 1, #localPlayers, 1 do
+                --             if players[i] == localPlayers[j] then table.remove(players, i) end
+                --         end
+                --     end
+                -- end
+
+                for _, pl in ipairs(players) do
+                    if xsb then data.sourceId = world.primaryPlayer() end
+                    data.targetId = pl -- Add the target player ID so we can filter received messages by target player on the other end on xStarbound clients.
+                    world.sendEntityMessage(pl, "scc_add_message", data)
+                end
+                if #globalStrings ~= 0 then
+                    local globalMsg = ""
+                    for _, str in ipairs(globalStrings) do
+                        globalMsg = globalMsg .. str .. " "
+                    end
+                    globalMsg:sub(1, -2)
+                    globalMsg = "{{" .. globalMsg .. "}}"
+                    -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
+                    chat.send(globalMsg, "Broadcast", false)
+                end
+                if #globalOocStrings ~= 0 then
+                    local globalOocMsg = ""
+                    for _, str in ipairs(globalOocStrings) do
+                        globalOocMsg = globalOocMsg .. str .. " "
+                    end
+                    globalOocMsg:sub(1, -2)
+                    globalOocMsg = "((" .. globalOocMsg .. "))"
+                    -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
+                    chat.send(globalOocMsg, "Broadcast", false)
+                end
+                return true
             end
-          end
-          rawText = newText:sub(1, #newText - 1)
-        end
-        while iCount <= #rawText and not globalFlag do
-          if parenSum == 3 then
-            globalFlag = true
-          end
-
-          local i = rawText:sub(iCount, iCount)
-          local langEnd = rawText:find("]", iCount)
-          if i == "+" then
-            sum = sum + 1
-          elseif i == "(" then
-            parenSum = parenSum + 1
-          elseif i == "{" and rawText:find("}", iCount) ~= nil then
-            globalFlag = true
-          elseif i == "[" and langEnd ~= nil then        --use this flag to check for default languages. A string without any noise won't have any language support
-            local langKey
-            if rawText:sub(iCount, langEnd) == "[]" then --checking for []
-              langKey = defaultKey
-              rawText = rawText:gsub("%[%]", "[" .. defaultKey .. "]")
-            else
-              langKey = rawText:sub(iCount + 1, langEnd - 1)
-            end
-            local upperKey = langKey:upper()
-
-            local langItem = player.getItemWithParameter("langKey", upperKey)
-
-            if (langItem == nil and upperKey ~= "!!") then
-              rawText = rawText:gsub("%[" .. langKey, "[" .. defaultKey)
-            end
-          else
-            parenSum = 0
-          end
-          iCount = iCount + 1
-        end
-        data.content = rawText
-        data.text = ""
-        if (parenSum == 2 or globalFlag) then
-          estRad = estRad * 2
-        elseif sum > 3 then
-          estRad = estRad * 1.5
-        else
-          estRad = estRad + (estRad * 0.25 + (3 * sum))
         end
 
-        --estrad should be pretty close to actual radius
+        local sendMessagePromise = {
+            finished = sendMessageToPlayers,
+            succeeded = function() return true end,
+        }
 
-
-        --this is where i'd change players if needed
-        local players = world.playerQuery(position, estRad, {
-          boundMode =
-          "position"
-        })
-        for _, pl in ipairs(players) do
-          world.sendEntityMessage(pl, "scc_add_message", data)
-        end
-
-
-        return true
-      end
+        promises:add(sendMessagePromise)
+        player.say("...")
     end
-
-    local sendMessagePromise = {
-      finished = sendMessageToPlayers,
-      succeeded = function() return true end
-    }
-
-    promises:add(sendMessagePromise)
-    player.say("...")
-  end
 end
 
 function dynamicprox:formatIncomingMessage(message)
-  --think about running this in local to allow players without the mod to still see messages
+    --think about running this in local to allow players without the mod to still see messages
 
-  if message.mode == "Prox" then
-    message.text = message.content
-    message.content = ""
+    if message.mode == "Prox" then
+        message.text = message.content
+        message.content = ""
 
-
-    if message.connection then --i don't know what receivingRestricted does
-      local authorEntityId = message.connection * -65536
-
-      if world.entityExists(authorEntityId) then
-        local authorPos = world.entityPosition(authorEntityId)
-        local playerPos = world.entityPosition(player.id())
-        local messageDistance = world.magnitude(playerPos, authorPos)
-        -- messageDistance = 30
-        local inSight = not world.lineTileCollision(authorPos, playerPos, { "Block", "Dynamic" }) --not doing dynamic, i think that's only for open doors
-
-        -- this is for later, testing to see if i can calculate how many tiles are between a sender and receiver
-        -- local testCol = world.lineTileCollisionPoint(authorPos, playerPos, { "Block", "Dynamic" })
-        -- sb.logWarn("messageDistance is " .. messageDistance)
-        -- if testCol ~= nil then
-        --   sb.logInfo("testCol is " .. dump(testCol))
-        --   local pos1 = testCol[1][1]
-        --   local pos2 = testCol[1][2]
-        --   sb.logInfo("pos1 "..pos1.." pos2 "..pos2)
-        --   sb.logInfo("distance is " .. world.magnitude(pos1, pos2))
-        -- end
-        local randSource = sb.makeRandomSource()
-
-
-
-
-
-        local actionRad = 200             --this is hard-coded for now, i might chagne it later
-        local loocRad = actionRad * 2     --2x actions, actions should already be pretty long though
-
-        local noiseRad = 0.25 * actionRad --talking, should be smaller than actions
-        --originally i made this a function, but tracking the values is difficult and it's easier to manually set them since there are only 9
-        local soundTable = {
-          [-4] = noiseRad / 10,
-          [-3] = noiseRad / 5,
-          [-2] = noiseRad / 4,
-          [-1] = noiseRad / 2,
-          [0] = noiseRad, --based on the default range of talking being 50, this should be good
-          [1] = noiseRad * 1.5,
-          [2] = noiseRad * 2,
-          [3] = noiseRad * 3,
-          [4] = noiseRad * 5,
-        }
-
-        --i dont like this but it'll have to do
-        local volTable = {
-          [noiseRad / 10] = -4,
-          [noiseRad / 5] = -3,
-          [noiseRad / 4] = -2,
-          [noiseRad / 2] = -1,
-          [noiseRad] = 0, --based on the default range of talking being 50, this should be good
-          [noiseRad * 1.5] = 1,
-          [noiseRad * 2] = 2,
-          [noiseRad * 3] = 3,
-          [noiseRad * 5] = 4,
-        }
-
-
-        local tVol, sVol = 0, 0
-        local tVolRad = noiseRad
-        local sVolRad = noiseRad
-        --iterate through message and get components here
-        local curMode = "action"
-        local prevMode = "action"
-        local prevDiffMode = "action"
-        local maxRad = 0
-        local rawText = message.text
-        local debugTable = {}                    --this will eventually be smashed together to make filterText
-        local textTable = {}                     --this will eventually be smashed together to make filterText
-        local validSum = 0                       --number of valid entries in the table
-        local cInd = 1                           --lua starts at 1 >:(
-        local charBuffer = ""
-        local languageCode = message.defaultLang --the !! shouldn't need to be set, but i'll leave it anyway
-        local radioMode = false                  --radio flag
-
-        local modeRadTypes = {
-          action = function()
-            return actionRad
-          end,
-          quote = function()
-            return tVolRad
-          end,
-          sound = function()
-            return sVolRad
-          end,
-          lOOC = function()
-            return loocRad
-          end,
-          gOOC = function()
-            return -1
-          end,
-        }
-
-        local function rawSub(sInd, eInd)
-          return rawText:sub(sInd, eInd)
-        end
-
-        --use this to construct the components
-        --any component indications (like :+) that remain should stay, use them for coloring if they aren't picked up here and reset after each component
-        local function formatInsert(str, radius, type, langKey, isValid, msgQuality, inSight, isRadio)
-          if langKey == nil then
-            langKey = "!!"
-          end
-
-
-          if msgQuality < 0 then
-            msgQuality = 100
-          end
-
-
-          table.insert(textTable, {
-            text = str,
-            radius = radius,
-            type = type,
-            langKey = langKey,
-            valid = isValid,
-            msgQuality = msgQuality,
-            hasLOS = inSight,
-            isRadio = isRadio,
-          })
-        end
-
-        local function parseDefault(letter)
-          charBuffer = charBuffer .. letter
-          cInd = cInd + 1
-        end
-
-        local function newMode(nextMode) --if radius is -1, the insert is instance wide
-          if (#charBuffer < 1 or charBuffer == '"' or charBuffer == '>' or charBuffer == '<') then
-            prevMode = curMode
-            curMode = nextMode
-            return
-          end
-
-          local useRad
-          useRad = modeRadTypes[curMode]()
-          local isValid = false                                                         --start with false
-          if messageDistance <= useRad or useRad == -1 then                             --if in range
-            isValid = true                                                              --the message is valid
-            if inSight == false and curMode == "action" then                            --if i can't see you and the mode is action
-              isValid = false                                                           --the message isn't valid anymore
-            elseif inSight == false and (curMode == "quote" or curMode == "sound") then --else, if i can't see you and the mode is quote or sound
-              --check for path
-              local noPathVol
-              if world.findPlatformerPath(authorPos, playerPos, root.monsterMovementSettings("smallflying")) then --if path is found
-                noPathVol = volTable[useRad] -
-                    1                                                                                             --set the volume to 1 (maybe 2 later on) level lower
-              else                                                                                                --if the path isn't found
-                noPathVol = volTable[useRad] -
-                    4                                                                                             --set the volume to 4 levels lower
-              end
-              if noPathVol > 4 then
-                noPathVol = 4
-              elseif noPathVol < -4 then
-                noPathVol = -4
-                isValid = false
-              end
-              useRad = soundTable[noPathVol]                  --set the radius to whatever the soundelevel would be
-              isValid = isValid and messageDistance <= useRad --set isvalid to the new value if it's still true
-            end
-          end
-
-          local msgQuality = 0
-          if isValid then
-            validSum = validSum + 1
-            msgQuality = math.min(((useRad / 2) / messageDistance) * 100, 100) --basically, check half the radius and take the percentage of that vs the message distance, cap at 100
-            maxRad = math.max(maxRad, useRad)
-          end
-
-          if useRad == -1 and maxRad ~= -1 then
-            maxRad = -1
-          end
-          formatInsert(charBuffer, useRad, curMode, languageCode, isValid, msgQuality, inSight, radioMode)
-          charBuffer = ""
-
-          prevMode = curMode
-          if (curMode ~= nextMode) then
-            prevDiffMode = curMode
-          end
-          curMode = nextMode
-        end
-
-
-        local defaultKey = getDefaultLang()
-
-        local mode_table = {
-          ['\"'] = function()
-            if curMode == "quote" then
-              parseDefault('')
-              newMode("action")
-            elseif curMode == "action" then
-              newMode("quote")
-              parseDefault('')
-            else
-              parseDefault('"')
-            end
-          end,
-          ['<'] = function()                                  --i could combine these two, but i don't want to
-            if curMode ~= "sound" and curMode ~= "quote" then --added quotes here so people can do the cool combine vocoder thing <::Pick up that can.::>
-              newMode("sound")
-            end
-            parseDefault('')
-          end,
-          ['>'] = function()
-            parseDefault('')
-            if curMode == "sound" then
-              newMode(prevDiffMode)
-            end
-          end,
-          [':'] = function()
-            local nextChar = rawSub(cInd + 1, cInd + 1)
-            if (nextChar == "+" or nextChar == "-" or nextChar == "=") then
-              newMode(curMode) --this happens to change volume, but mode isn't actually changing
-
-              local maxAmp = 4 --maximum chars after the colon
-
-              local lStart, lEnd = rawText:find(":%++", cInd)
-              local qStart, qEnd = rawText:find(":%-+", cInd)
-              local eStart, eEnd = rawText:find(":%=+", cInd)
-              local nCStart, nCEnd
-
-
-              if (qStart == nil) then
-                qStart = #rawText
-              end
-              if (qEnd == nil) then
-                qEnd = #rawText
-              end
-              if (lStart == nil) then
-                lStart = #rawText
-              end
-              if (lEnd == nil) then
-                lEnd = #rawText
-              end
-              if (eStart == nil) then
-                eStart = #rawText
-              end
-              if (eEnd == nil) then
-                eEnd = #rawText
-              end
-
-              if math.min(eStart, lStart, qStart) == eStart then
-                nCStart = eStart
-                nCEnd = eEnd
-              elseif math.min(eStart, lStart, qStart) == lStart then
-                nCStart = lStart
-                nCEnd = lEnd
-              elseif math.min(eStart, lStart, qStart) == qStart then
-                nCStart = qStart
-                nCEnd = qEnd
-              end
-
-              local doVolume = "none"
-              --in these modes, ignore the volume controls
-              if curMode == 'radio' or curMode == 'gOOC' or curMode == 'lOOC' then
-                cInd = nCEnd + 1
-              elseif curMode == 'action' then
-                local nextInd = rawText:find("[\"<]", cInd)
-
-
-                if nextChar == nil then --if they just put this at the end for some reason
-                  cInd = nCEnd + 1
-                elseif nextInd ~= nil then
-                  nextChar = rawSub(nextInd, nextInd)
+        if message.connection then --i don't know what receivingRestricted does
+            -- FezzedOne: Allows OpenStarbound and StarExtensions clients to correctly display received messages from xStarbound clients.
+            local authorEntityId = message.sourceId or (message.connection * -65536)
+            local receiverEntityId = message.targetId or player.id()
+            local ownPlayers = world.ownPlayers()
+            local isLocalPlayer = function(entityId)
+                if not xsb then return true end
+                for _, plr in ipairs(ownPlayers) do
+                    if entityId == plr then return true end
                 end
-                if nextChar == '"' then
-                  doVolume = "quote"
-                else
-                  doVolume = "sound"
+                return false
+            end
+            if xsb then
+                if message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
+                    local receiverName = world.entityName(receiverEntityId)
+                    if #ownPlayers ~= 1 then message.nickname = message.nickname .. " -> " .. receiverName end
+                    if message.targetId ~= player.id() then message.mode = "ProxSecondary" end
                 end
-              else
-                doVolume = curMode
-              end
+            end
 
-              if doVolume ~= 'none' then
-                local sum = 0
-                local nextStr = rawSub(nCStart + 1, nCEnd)
+            if world.entityExists(authorEntityId) then
+                local authorPos = world.entityPosition(authorEntityId)
+                local playerPos =
+                    world.entityPosition(world.entityExists(receiverEntityId) and receiverEntityId or player.id())
+                local messageDistance = world.magnitude(playerPos, authorPos)
+                -- messageDistance = 30
+                local inSight = not world.lineTileCollision(authorPos, playerPos, { "Block", "Dynamic" }) --not doing dynamic, i think that's only for open doors
 
-                if doVolume == "quote" then
-                  sum = tVol
-                else
-                  sum = sVol
+                -- this is for later, testing to see if i can calculate how many tiles are between a sender and receiver
+                -- local testCol = world.lineTileCollisionPoint(authorPos, playerPos, { "Block", "Dynamic" })
+                -- sb.logWarn("messageDistance is " .. messageDistance)
+                -- if testCol ~= nil then
+                --   sb.logInfo("testCol is " .. dump(testCol))
+                --   local pos1 = testCol[1][1]
+                --   local pos2 = testCol[1][2]
+                --   sb.logInfo("pos1 "..pos1.." pos2 "..pos2)
+                --   sb.logInfo("distance is " .. world.magnitude(pos1, pos2))
+                -- end
+                local randSource = sb.makeRandomSource()
+
+                local actionRad = self.proxActionRadius -- FezzedOne: Un-hardcoded the action radius.
+                local loocRad = self.proxOocRadius -- actionRad * 2 -- FezzedOne: Un-hardcoded the local OOC radius.
+                local noiseRad = self.proxTalkRadius -- FezzedOne: Un-hardcoded the talking radius.
+
+                --originally i made this a function, but tracking the values is difficult and it's easier to manually set them since there are only 9
+                local soundTable = {
+                    [-4] = noiseRad / 10,
+                    [-3] = noiseRad / 5,
+                    [-2] = noiseRad / 4,
+                    [-1] = noiseRad / 2,
+                    [0] = noiseRad, --based on the default range of talking being 50, this should be good
+                    [1] = noiseRad * 1.5,
+                    [2] = noiseRad * 2,
+                    [3] = noiseRad * 3,
+                    [4] = noiseRad * 5,
+                }
+
+                --i dont like this but it'll have to do
+                local volTable = {
+                    [noiseRad / 10] = -4,
+                    [noiseRad / 5] = -3,
+                    [noiseRad / 4] = -2,
+                    [noiseRad / 2] = -1,
+                    [noiseRad] = 0, --based on the default range of talking being 50, this should be good
+                    [noiseRad * 1.5] = 1,
+                    [noiseRad * 2] = 2,
+                    [noiseRad * 3] = 3,
+                    [noiseRad * 5] = 4,
+                }
+
+                local tVol, sVol = 0, 0
+                local tVolRad = noiseRad
+                local sVolRad = noiseRad
+                --iterate through message and get components here
+                local curMode = "action"
+                local prevMode = "action"
+                local prevDiffMode = "action"
+                local maxRad = 0
+                local rawText = message.text
+                local debugTable = {} --this will eventually be smashed together to make filterText
+                local textTable = {} --this will eventually be smashed together to make filterText
+                local validSum = 0 --number of valid entries in the table
+                local cInd = 1 --lua starts at 1 >:(
+                local charBuffer = ""
+                local languageCode = message.defaultLang --the !! shouldn't need to be set, but i'll leave it anyway
+                local radioMode = false --radio flag
+
+                local modeRadTypes = {
+                    action = function() return actionRad end,
+                    quote = function() return tVolRad end,
+                    sound = function() return sVolRad end,
+                    lOOC = function() return loocRad end,
+                    gOOC = function() return -1 end,
+                }
+
+                local function rawSub(sInd, eInd) return rawText:sub(sInd, eInd) end
+
+                --use this to construct the components
+                --any component indications (like :+) that remain should stay, use them for coloring if they aren't picked up here and reset after each component
+                local function formatInsert(str, radius, type, langKey, isValid, msgQuality, inSight, isRadio)
+                    if langKey == nil then langKey = "!!" end
+
+                    if msgQuality < 0 then msgQuality = 100 end
+
+                    table.insert(textTable, {
+                        text = str,
+                        radius = radius,
+                        type = type,
+                        langKey = langKey,
+                        valid = isValid,
+                        msgQuality = msgQuality,
+                        hasLOS = inSight,
+                        isRadio = isRadio,
+                    })
                 end
 
-                for i in nextStr:gmatch(".") do
-                  if i == '+' then
-                    sum = sum + 1
-                  elseif i == '-' then
-                    sum = sum - 1
-                  elseif i == '=' then
-                    sum = 0
-                    if doVolume == "quote" then
-                      tVolRad = noiseRad
-                    else
-                      sVolRad = noiseRad
+                local function parseDefault(letter)
+                    charBuffer = charBuffer .. letter
+                    cInd = cInd + 1
+                end
+
+                local function newMode(nextMode) --if radius is -1, the insert is instance wide
+                    if #charBuffer < 1 or charBuffer == '"' or charBuffer == ">" or charBuffer == "<" then
+                        prevMode = curMode
+                        curMode = nextMode
+                        return
                     end
-                  end
-                end
-                cInd = nCEnd
 
-                sum = math.min(math.max(sum, -4), 4)
-
-                if doVolume == "quote" then
-                  tVol = sum
-                  tVolRad = soundTable[sum]
-                else
-                  sVol = sum
-                  sVolRad = soundTable[sum]
-                end
-              end
-              cInd = nCEnd + 1
-            else
-              parseDefault(":")
-            end
-          end,
-          ['*'] = function() --leave this for the visual alterations later on
-            -- i have this commented out so people can keep asterisks in actions if they want
-            -- if curMode == 'action' then
-            --   cInd = cInd + 1
-            -- else
-            --   parseDefault("*")
-            -- end
-            parseDefault("*")
-          end,
-          ['/'] = function()
-            parseDefault("*")
-          end,
-          ['\\'] = function()
-            parseDefault("\\")
-          end,
-          ['('] = function() --check for number of parentheses
-            local nextChar = rawSub(cInd + 1, cInd + 1)
-            if nextChar == "(" then
-              local oocEnd = 0
-              local oocBump = 0
-              local oocType
-              local oocRad
-              if rawSub(cInd + 2, cInd + 2) == "(" then
-                --global ooc
-                _, oocEnd = rawText:find("%)%)%)+", cInd) --the + catches extra parentheses in case someone adds more than 3
-                oocType = "gOOC"
-                oocBump = 2
-                oocRad = -1
-              else
-                --local ooc
-                _, oocEnd = rawText:find("%)%)+", cInd)
-                oocBump = 1
-                oocType = "lOOC"
-                oocRad = actionRad * 2
-              end
-
-
-              if oocEnd ~= nil then
-                newMode(oocType)
-                charBuffer = charBuffer .. rawSub(cInd, oocEnd)
-                newMode(prevMode)
-              else
-                charBuffer = charBuffer .. rawSub(cInd, cInd + oocBump)
-                cInd = cInd + oocBump
-                oocEnd = cInd
-              end
-
-              cInd = oocEnd + 1
-            else
-              parseDefault("(")
-            end
-          end,
-          ['{'] = function() --this should function as a global IC message, but finding the playercount is not possible (or i'm stupid) clientside
-            --i'm not doing secure radio because you can edit this file and ignore the password requirement with it
-            --if you want to do that, just do it over group chat or something
-            --this is where a stagehand serverside would be useful. In the future it might be worth exploring that
-
-            --maybe set up multiple radio ranges with multiple brackets? seems kind of pointless imo
-            newMode(curMode)
-            radioMode = true
-            parseDefault("{")
-          end,
-          ['}'] = function()
-            if rawSub(cInd + 1, cInd + 1) == "\"" and curMode == "quote" then
-              parseDefault("}")
-              parseDefault("\"")
-              newMode("action")
-            else
-              parseDefault("}")
-              newMode(curMode)
-            end
-
-
-            radioMode = false
-            -- cInd = cInd + 1
-          end,
-          ['|'] = function()
-            local fStart, fEnd = rawText:find("%d+|", cInd)
-
-            if fStart ~= nil and fEnd ~= nil then
-              local timeNum = message.time:gsub("%D", "")
-              local mixNum = tonumber(timeNum .. math.abs(authorEntityId))
-              randSource:init(mixNum)
-              local numMax = rawSub(fStart, fEnd - 1):gsub("%D", "")
-              local roll = randSource:randInt(1, tonumber(numMax))
-              parseDefault("|" .. roll .. "|")
-              cInd = fEnd + 1
-            else
-              parseDefault("|")
-            end
-          end,
-          ['['] = function()
-            local fStart, fEnd = rawText:find("%[%S%S+]", cInd - 1)
-            if fStart ~= nil and fEnd ~= nil then
-              local newCode = rawSub(fStart + 1, fEnd - 1)
-
-              if languageCode ~= newCode and curMode == "quote" then
-                newMode(curMode)
-              end
-              languageCode = newCode:upper()
-              cInd = rawText:find("%S", fEnd + 1) or
-                  #rawText                             --set index to the next non whitespace character after the code
-            elseif rawSub(cInd, cInd + 1) == '[]' then --this should never happen anymore
-              newMode(curMode)
-              languageCode = defaultKey
-              cInd = cInd + 2
-            else
-              parseDefault("[")
-            end
-          end,
-          default = function(letter)
-            charBuffer = charBuffer .. letter
-            cInd = cInd + 1
-          end,
-        }
-
-        local c
-
-        --run this loop to generate textTable, then concatenate
-        while cInd <= #rawText do
-          c = rawSub(cInd, cInd)
-
-          if mode_table[c] then
-            mode_table[c]()
-          else
-            parseDefault(c)
-          end
-        end
-        newMode(curMode) --makes sure nothing is left out
-
-        local function trim(s)
-          local l = 1
-          while string.sub(s, l, l) == ' ' do
-            l = l + 1
-          end
-          local r = #s
-          while string.sub(s, r, r) == ' ' do
-            r = r - 1
-          end
-          return string.sub(s, l, r)
-        end
-
-        local function degradeMessage(str, quality)
-          local returnStr = ""
-          local char
-          local iCount = 1
-          local rMax = (#str - 2) - ((#str - 2) * (quality / 100)) --basically, how many characters can be "-", helps
-          local rCount = 0
-          while iCount <= #str do
-            char = str:sub(iCount, iCount)
-            if char == "[" and str:sub(iCount + 3, iCount + 3) == "]" then
-              returnStr = returnStr .. str:sub(iCount, iCount + 3)
-              iCount = iCount + 4
-            elseif char == "^" and str:find(";", iCount) ~= nil then
-              local nextSemi = str:find(";", iCount)
-              returnStr = returnStr .. str:sub(iCount, nextSemi)
-              iCount = nextSemi + 1
-            else
-              randSource:init()
-
-              local letterRoll = randSource:randInt(1, 100)
-              if letterRoll > quality and char:match("[%p%s]") == nil then
-                char = "-"
-                rCount = rCount + 1
-              end
-              returnStr = returnStr .. char
-              iCount = iCount + 1
-            end
-          end
-          return returnStr
-        end
-
-        local function wordBytes(word)
-          local returnStr = ""
-          for char in word:gmatch(".") do
-            char = char:lower()
-            returnStr = returnStr .. math.abs(string.byte(char) - 100)
-          end
-          return returnStr
-        end
-
-        local function langWordRep(word, byteLC)
-          local vowels = { 'a', 'e', 'i', 'o', 'u', 'y' }
-          local consonants = { 'b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't',
-            'v', 'w',
-            'x', 'z' }
-          local pickInd = 0
-          local newWord = ""
-          randSource:init(tonumber(byteLC .. wordBytes(word)))
-          for char in word:gmatch(".") do
-            local charLower = char:lower()
-            local isLower = char == charLower
-            if charLower:match("[aeiouy]") then
-              local randNum = randSource:randInt(1, #vowels)
-              char = vowels[randNum]
-            elseif not char:match("[%p]") then
-              local randNum = randSource:randInt(1, #consonants)
-              char = consonants[randNum]
-            end
-            if not isLower then
-              char = char:upper()
-            end
-            newWord = newWord .. char
-          end
-          return newWord
-        end
-
-        local function langScramble(str, prof, langCode, msgColor, langColor)
-          local returnStr = ""
-          str = str .. " "
-          str = str:gsub("  ", " ")
-          local rCount = 0
-          local words = 0
-          for i in str:gmatch(".") do
-            if i == " " then
-              words = words + 1
-            end
-          end
-          words = words + 1
-          local rMax = words - (words * (prof / 100))
-          local wordBuffer = ""
-          local byteLC = wordBytes(langCode)
-          local iCount = 1
-          local char
-
-          if langColor == nil then
-            local hexDigits = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F" }
-            local randSource = sb.makeRandomSource()
-            local hexMin = 1
-
-            --not sure if there's an cleaner way to do this
-            randSource:init(byteLC .. wordBytes("Red One"))
-            local rNumR = hexDigits[randSource:randInt(hexMin, 16)]
-            randSource:init(byteLC .. wordBytes("Green Two"))
-            local rNumG = hexDigits[randSource:randInt(hexMin, 16)]
-            randSource:init(byteLC .. wordBytes("Blue Three"))
-            local rNumB = hexDigits[randSource:randInt(hexMin, 16)]
-            randSource:init(byteLC .. wordBytes("Red Four"))
-            local rNumR2 = hexDigits[randSource:randInt(hexMin, 16)]
-            randSource:init(byteLC .. wordBytes("Green Five"))
-            local rNumG2 = hexDigits[randSource:randInt(hexMin, 16)]
-            randSource:init(byteLC .. wordBytes("Blue Six"))
-            local rNumB2 = hexDigits[randSource:randInt(hexMin, 16)]
-            langColor = "#" .. rNumR .. rNumG .. rNumB .. rNumR2 .. rNumG2 .. rNumB2
-          end
-
-
-          while iCount <= #str do
-            char = str:sub(iCount, iCount)
-            if char == "[" and str:sub(iCount + 3, iCount + 3) == "]" then
-              returnStr = returnStr .. char .. str:sub(iCount + 1, iCount + 3)
-              iCount = iCount + 3
-            elseif char == " " and not wordBuffer:match("%a") and #wordBuffer > 0 then
-              returnStr = returnStr .. " " .. wordBuffer
-              wordBuffer = ""
-            elseif char ~= "'" and char:match("[%s%p]") then
-              if #wordBuffer > 0 then
-                local byteWord = wordBytes(wordBuffer)
-                randSource:init(tonumber(wordBytes(player.uniqueId()) .. byteLC .. byteWord))
-                local wordRoll = randSource:randInt(1, 100)
-                if wordRoll > prof then
-                  wordBuffer = langWordRep(trim(wordBuffer), wordRoll, byteLC)
-                  wordBuffer = "^" .. langColor .. ";" .. wordBuffer .. "^" .. msgColor .. ";"
-                  rCount = rCount + 1
-                end
-              end
-              returnStr = returnStr .. wordBuffer .. char
-              wordBuffer = ""
-            else
-              wordBuffer = wordBuffer .. char
-            end
-            iCount = iCount + 1
-          end
-
-          if returnStr:match("%s", #returnStr) then
-            returnStr = returnStr:sub(0, #returnStr - 1)
-          end
-
-
-          randSource:init()
-          return returnStr
-        end
-
-        local colorTable = { --transparency is an options here, but it makes things hard to read
-          [-4] = "#555",
-          [-3] = "#777",
-          [-2] = "#999",
-          [-1] = "#bbb",
-          [0] = "#ddd",
-          [1] = "#fff",
-          [2] = "#daa",
-          [3] = "#d66",
-          [4] = "#d00",
-        }
-
-        local function colorWithin(str, char, color, prevColor)
-          local colorOn = false
-          local charBuffer = ""
-          for i in str:gmatch(".") do
-            if i == char then
-              if colorOn == false then
-                charBuffer = charBuffer .. "^" .. color .. ";"
-                colorOn = true
-              else
-                charBuffer = charBuffer .. "^" .. prevColor .. ";"
-                colorOn = false
-              end
-            else
-              --put this outside the if statement to make the characters appear as well as colors
-              charBuffer = charBuffer .. i
-            end
-          end
-          print("Charbuffer is " .. charBuffer)
-          return charBuffer
-        end
-
-
-        local function cleanDoubleSpaces(str)
-          --run a loop with the string, ignore codes (^whatever;), then remove more than one space in a row
-          local cleanStr = ""
-          local iCount = 1
-          local prevChar = ""
-          local prevColor = ""
-
-          while iCount <= #str do
-            local char = str:sub(iCount, iCount)
-            local nextSemi = 0
-
-            if char == "^" then
-              nextSemi = str:find(";", iCount)
-
-              if nextSemi ~= nil then
-                local colorCode = str:sub(iCount, nextSemi)
-                if colorCode ~= prevColor then
-                  cleanStr = cleanStr .. colorCode
-                end
-                prevColor = colorCode
-                iCount = nextSemi
-              end
-            elseif char ~= " " or prevChar ~= " " then
-              cleanStr = cleanStr .. char
-              prevChar = char
-            end
-            iCount = iCount + 1
-          end
-          cleanStr = cleanStr:gsub("%{ ", "{")
-          cleanStr = cleanStr:gsub(" %}", "}")
-          return cleanStr
-        end
-
-        --do visual formatting here.
-        --for dialogue (NOT sounds), start degrading the quality of the message at 50% of the quotes's radius
-        local tableStr = ""
-        local prevStr = ""
-        local quoteCombo = ""
-        local soundCombo = ""
-        local prevType = "action"
-        local quoteOpen = false
-        local soundOpen = false
-        local hasValids = false
-        local chunkStr
-        local chunkType
-        local langBank = {}               --populate with languages in inventory when you find them
-        local prevLang = getDefaultLang() --either the player's default language, or !!
-
-        if maxRad ~= -1 and (messageDistance > maxRad and validSum == 0) then
-          message.text = ""
-        else
-          chunkType = nil
-
-          local prevChunk = ""
-          local repeatFlag = false
-          table.insert(textTable, {
-            text = "",
-            radius = "0",
-            type = "bad",
-            langKey = ":(",
-            valid = false,
-            msgQuality = 0
-          })
-
-
-
-          for k, v in pairs(textTable) do
-            if v['hasLOS'] == false and chunkType == "action" then
-              v['valid'] = false
-            end
-            if v['valid'] then
-              hasValids = true
-            end
-          end
-          for k, v in pairs(textTable) do
-            if v['radius'] == -1 or v['isRadio'] == true then
-              v['valid'] = true
-            end
-
-
-            chunkStr = v['text']
-            chunkType = v['type']
-            local langKey = v['langKey']
-            if v['valid'] == true or (chunkType == "quote" and ((k > 1 and textTable[k - 1]['type'] == "quote") or (k < #textTable and textTable[k + 1]['type'] == "quote"))) then --check if this is surrounded by quotes
-              v['valid'] = true                                                                                                                                                    --this should be set to true in here, since everything in this block should show up on the screen
-              -- remember, noiserad is a const and radius is for the message
-
-              local colorOverride = chunkStr:find("%^%#") ~=
-                  nil                    --don't touch colors if this is true
-              local actionColor = "#fff" --white for non sound based chunks
-              local msgColor = "#fff"    --white for non sound based chunks
-              --disguise unheard stuff
-              if chunkType == "sound" then
-                if not colorOverride then
-                  msgColor = colorTable[volTable[v['radius']]]
-                  chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
-                end
-              elseif chunkType == "quote" then
-                msgColor = colorTable[volTable[v['radius']]]
-
-                if chunkType == 'quote' and langKey ~= "!!" then
-                  local langProf, langColor
-                  if langBank[langKey] ~= nil then
-                    langProf = langBank[langKey]["prof"]
-                    langColor = langBank[langKey]["color"]
-                  end
-                  if langProf == nil then
-                    local newLang = player.getItemWithParameter("langKey", langKey) or nil
-                    if newLang then
-                      langColor = newLang['parameters']['color']
-                      local hasItem = player.hasCountOfItem(newLang, true)
-
-                      if hasItem then
-                        langProf = hasItem * 10
-                      else
-                        langProf = 0
-                      end
-                      langBank[langKey] = {
-                        prof = langProf,
-                        color = langColor
-                      }
-                    else
-                      langProf = 0
+                    local useRad
+                    useRad = modeRadTypes[curMode]()
+                    local isValid = false --start with false
+                    if messageDistance <= useRad or useRad == -1 then --if in range
+                        isValid = true --the message is valid
+                        if inSight == false and curMode == "action" then --if i can't see you and the mode is action
+                            isValid = false --the message isn't valid anymore
+                        elseif inSight == false and (curMode == "quote" or curMode == "sound") then --else, if i can't see you and the mode is quote or sound
+                            --check for path
+                            local noPathVol
+                            if
+                                world.findPlatformerPath(
+                                    authorPos,
+                                    playerPos,
+                                    root.monsterMovementSettings("smallflying")
+                                )
+                            then --if path is found
+                                noPathVol = volTable[useRad] - 1 --set the volume to 1 (maybe 2 later on) level lower
+                            else --if the path isn't found
+                                noPathVol = volTable[useRad] - 4 --set the volume to 4 levels lower
+                            end
+                            if noPathVol > 4 then
+                                noPathVol = 4
+                            elseif noPathVol < -4 then
+                                noPathVol = -4
+                                isValid = false
+                            end
+                            useRad = soundTable[noPathVol] --set the radius to whatever the soundelevel would be
+                            isValid = isValid and messageDistance <= useRad --set isvalid to the new value if it's still true
+                        end
                     end
-                  end
 
-                  if langProf < 100 then
-                    --scramble the word
-                    chunkStr =
-                        langScramble(trim(chunkStr), langProf, langKey, msgColor, langColor)
-                  end
+                    local msgQuality = 0
+                    if isValid then
+                        validSum = validSum + 1
+                        msgQuality = math.min(((useRad / 2) / messageDistance) * 100, 100) --basically, check half the radius and take the percentage of that vs the message distance, cap at 100
+                        maxRad = math.max(maxRad, useRad)
+                    end
+
+                    if useRad == -1 and maxRad ~= -1 then maxRad = -1 end
+                    formatInsert(charBuffer, useRad, curMode, languageCode, isValid, msgQuality, inSight, radioMode)
+                    charBuffer = ""
+
+                    prevMode = curMode
+                    if curMode ~= nextMode then prevDiffMode = curMode end
+                    curMode = nextMode
                 end
-                --check message quality
-                if v['msgQuality'] < 100 and chunkType == 'quote' then
-                  chunkStr = degradeMessage(trim(chunkStr), v['msgQuality'])
+
+                local defaultKey = getDefaultLang()
+
+                local mode_table = {
+                    ['"'] = function()
+                        if curMode == "quote" then
+                            parseDefault("")
+                            newMode("action")
+                        elseif curMode == "action" then
+                            newMode("quote")
+                            parseDefault("")
+                        else
+                            parseDefault('"')
+                        end
+                    end,
+                    ["<"] = function() --i could combine these two, but i don't want to
+                        if curMode ~= "sound" and curMode ~= "quote" then --added quotes here so people can do the cool combine vocoder thing <::Pick up that can.::>
+                            newMode("sound")
+                        end
+                        parseDefault("")
+                    end,
+                    [">"] = function()
+                        parseDefault("")
+                        if curMode == "sound" then newMode(prevDiffMode) end
+                    end,
+                    [":"] = function()
+                        local nextChar = rawSub(cInd + 1, cInd + 1)
+                        if nextChar == "+" or nextChar == "-" or nextChar == "=" then
+                            newMode(curMode) --this happens to change volume, but mode isn't actually changing
+
+                            local maxAmp = 4 --maximum chars after the colon
+
+                            local lStart, lEnd = rawText:find(":%++", cInd)
+                            local qStart, qEnd = rawText:find(":%-+", cInd)
+                            local eStart, eEnd = rawText:find(":%=+", cInd)
+                            local nCStart, nCEnd
+
+                            if qStart == nil then qStart = #rawText end
+                            if qEnd == nil then qEnd = #rawText end
+                            if lStart == nil then lStart = #rawText end
+                            if lEnd == nil then lEnd = #rawText end
+                            if eStart == nil then eStart = #rawText end
+                            if eEnd == nil then eEnd = #rawText end
+
+                            if math.min(eStart, lStart, qStart) == eStart then
+                                nCStart = eStart
+                                nCEnd = eEnd
+                            elseif math.min(eStart, lStart, qStart) == lStart then
+                                nCStart = lStart
+                                nCEnd = lEnd
+                            elseif math.min(eStart, lStart, qStart) == qStart then
+                                nCStart = qStart
+                                nCEnd = qEnd
+                            end
+
+                            local doVolume = "none"
+                            --in these modes, ignore the volume controls
+                            if curMode == "radio" or curMode == "gOOC" or curMode == "lOOC" then
+                                cInd = nCEnd + 1
+                            elseif curMode == "action" then
+                                local nextInd = rawText:find('["<]', cInd)
+
+                                if nextChar == nil then --if they just put this at the end for some reason
+                                    cInd = nCEnd + 1
+                                elseif nextInd ~= nil then
+                                    nextChar = rawSub(nextInd, nextInd)
+                                end
+                                if nextChar == '"' then
+                                    doVolume = "quote"
+                                else
+                                    doVolume = "sound"
+                                end
+                            else
+                                doVolume = curMode
+                            end
+
+                            if doVolume ~= "none" then
+                                local sum = 0
+                                local nextStr = rawSub(nCStart + 1, nCEnd)
+
+                                if doVolume == "quote" then
+                                    sum = tVol
+                                else
+                                    sum = sVol
+                                end
+
+                                for i in nextStr:gmatch(".") do
+                                    if i == "+" then
+                                        sum = sum + 1
+                                    elseif i == "-" then
+                                        sum = sum - 1
+                                    elseif i == "=" then
+                                        sum = 0
+                                        if doVolume == "quote" then
+                                            tVolRad = noiseRad
+                                        else
+                                            sVolRad = noiseRad
+                                        end
+                                    end
+                                end
+                                cInd = nCEnd
+
+                                sum = math.min(math.max(sum, -4), 4)
+
+                                if doVolume == "quote" then
+                                    tVol = sum
+                                    tVolRad = soundTable[sum]
+                                else
+                                    sVol = sum
+                                    sVolRad = soundTable[sum]
+                                end
+                            end
+                            cInd = nCEnd + 1
+                        else
+                            parseDefault(":")
+                        end
+                    end,
+                    ["*"] = function() --leave this for the visual alterations later on
+                        -- i have this commented out so people can keep asterisks in actions if they want
+                        -- if curMode == 'action' then
+                        --   cInd = cInd + 1
+                        -- else
+                        --   parseDefault("*")
+                        -- end
+                        parseDefault("*")
+                    end,
+                    ["/"] = function() parseDefault("*") end,
+                    ["\\"] = function() parseDefault("\\") end,
+                    ["("] = function() --check for number of parentheses
+                        local nextChar = rawSub(cInd + 1, cInd + 1)
+                        if nextChar == "(" then
+                            local oocEnd = 0
+                            local oocBump = 0
+                            local oocType
+                            local oocRad
+                            if rawSub(cInd + 2, cInd + 2) == "(" then
+                                --global ooc
+                                _, oocEnd = rawText:find("%)%)%)+", cInd) --the + catches extra parentheses in case someone adds more than 3
+                                oocType = "gOOC"
+                                oocBump = 2
+                                oocRad = -1
+                            else
+                                --local ooc
+                                _, oocEnd = rawText:find("%)%)+", cInd)
+                                oocBump = 1
+                                oocType = "lOOC"
+                                oocRad = actionRad * 2
+                            end
+
+                            if oocEnd ~= nil then
+                                newMode(oocType)
+                                charBuffer = charBuffer .. rawSub(cInd, oocEnd)
+                                newMode(prevMode)
+                            else
+                                charBuffer = charBuffer .. rawSub(cInd, cInd + oocBump)
+                                cInd = cInd + oocBump
+                                oocEnd = cInd
+                            end
+
+                            cInd = oocEnd + 1
+                        else
+                            parseDefault("(")
+                        end
+                    end,
+                    ["{"] = function() --this should function as a global IC message, but finding the playercount is not possible (or i'm stupid) clientside
+                        --i'm not doing secure radio because you can edit this file and ignore the password requirement with it
+                        --if you want to do that, just do it over group chat or something
+                        --this is where a stagehand serverside would be useful. In the future it might be worth exploring that
+
+                        --maybe set up multiple radio ranges with multiple brackets? seems kind of pointless imo
+                        newMode(curMode)
+                        radioMode = true
+                        parseDefault("{")
+                    end,
+                    ["}"] = function()
+                        if rawSub(cInd + 1, cInd + 1) == '"' and curMode == "quote" then
+                            parseDefault("}")
+                            parseDefault('"')
+                            newMode("action")
+                        else
+                            parseDefault("}")
+                            newMode(curMode)
+                        end
+
+                        radioMode = false
+                        -- cInd = cInd + 1
+                    end,
+                    ["|"] = function()
+                        local fStart, fEnd = rawText:find("%d+|", cInd)
+
+                        if fStart ~= nil and fEnd ~= nil then
+                            local timeNum = message.time:gsub("%D", "")
+                            local mixNum = tonumber(timeNum .. math.abs(authorEntityId))
+                            randSource:init(mixNum)
+                            local numMax = rawSub(fStart, fEnd - 1):gsub("%D", "")
+                            local roll = randSource:randInt(1, tonumber(numMax))
+                            parseDefault("|" .. roll .. "|")
+                            cInd = fEnd + 1
+                        else
+                            parseDefault("|")
+                        end
+                    end,
+                    ["["] = function()
+                        local fStart, fEnd = rawText:find("%[%S%S+]", cInd - 1)
+                        if fStart ~= nil and fEnd ~= nil then
+                            local newCode = rawSub(fStart + 1, fEnd - 1)
+
+                            if languageCode ~= newCode and curMode == "quote" then newMode(curMode) end
+                            languageCode = newCode:upper()
+                            cInd = rawText:find("%S", fEnd + 1) or #rawText --set index to the next non whitespace character after the code
+                        elseif rawSub(cInd, cInd + 1) == "[]" then --this should never happen anymore
+                            newMode(curMode)
+                            languageCode = defaultKey
+                            cInd = cInd + 2
+                        else
+                            parseDefault("[")
+                        end
+                    end,
+                    default = function(letter)
+                        charBuffer = charBuffer .. letter
+                        cInd = cInd + 1
+                    end,
+                }
+
+                local c
+
+                --run this loop to generate textTable, then concatenate
+                while cInd <= #rawText do
+                    c = rawSub(cInd, cInd)
+
+                    if mode_table[c] then
+                        mode_table[c]()
+                    else
+                        parseDefault(c)
+                    end
+                end
+                newMode(curMode) --makes sure nothing is left out
+
+                local function trim(s)
+                    local l = 1
+                    while string.sub(s, l, l) == " " do
+                        l = l + 1
+                    end
+                    local r = #s
+                    while string.sub(s, r, r) == " " do
+                        r = r - 1
+                    end
+                    return string.sub(s, l, r)
                 end
 
-                if not colorOverride then
-                  chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                local function degradeMessage(str, quality)
+                    local returnStr = ""
+                    local char
+                    local iCount = 1
+                    local rMax = (#str - 2) - ((#str - 2) * (quality / 100)) --basically, how many characters can be "-", helps
+                    local rCount = 0
+                    while iCount <= #str do
+                        char = str:sub(iCount, iCount)
+                        if char == "[" and str:sub(iCount + 3, iCount + 3) == "]" then
+                            returnStr = returnStr .. str:sub(iCount, iCount + 3)
+                            iCount = iCount + 4
+                        elseif char == "^" and str:find(";", iCount) ~= nil then
+                            local nextSemi = str:find(";", iCount)
+                            returnStr = returnStr .. str:sub(iCount, nextSemi)
+                            iCount = nextSemi + 1
+                        else
+                            randSource:init()
+
+                            local letterRoll = randSource:randInt(1, 100)
+                            if letterRoll > quality and char:match("[%p%s]") == nil then
+                                char = "-"
+                                rCount = rCount + 1
+                            end
+                            returnStr = returnStr .. char
+                            iCount = iCount + 1
+                        end
+                    end
+                    return returnStr
                 end
 
-                --add in languagee indicator
-                if langKey ~= prevLang then
-                  chunkStr = "^#fff;[" .. langKey .. "]^" .. msgColor .. "; " .. chunkStr
-                  prevLang = langKey
+                local function wordBytes(word)
+                    local returnStr = ""
+                    for char in word:gmatch(".") do
+                        char = char:lower()
+                        returnStr = returnStr .. math.abs(string.byte(char) - 100)
+                    end
+                    return returnStr
                 end
-              end
-              chunkStr = chunkStr:gsub("%^%#fff%;%^%#fff;", "^#fff;")
-              chunkStr = chunkStr:gsub("%^" .. msgColor .. ";%^#fff;", "^#fff;")
-              chunkStr = chunkStr:gsub("%^" .. msgColor .. ";%^" .. msgColor .. ";", "^" .. msgColor .. ";")
 
+                local function langWordRep(word, byteLC)
+                    local vowels = {
+                        "a",
+                        "e",
+                        "i",
+                        "o",
+                        "u",
+                        "y",
+                    }
+                    local consonants = {
+                        "b",
+                        "c",
+                        "d",
+                        "f",
+                        "g",
+                        "h",
+                        "j",
+                        "k",
+                        "l",
+                        "m",
+                        "n",
+                        "p",
+                        "q",
+                        "r",
+                        "s",
+                        "t",
+                        "v",
+                        "w",
+                        "x",
+                        "z",
+                    }
+                    -- FezzedOne: Merge a list into a Lua pattern. Assumes input doesn't contain any characters that need to be escaped.
+                    local function mergePattern(list)
+                        local pattern = "["
+                        for _, char in ipairs(list) do
+                            pattern = pattern .. char
+                        end
+                        return pattern .. "]"
+                    end
 
-              --recolors certain things for emphasis
-              if chunkType ~= "action" then                             --allow asterisks to stay in actions
-                chunkStr = colorWithin(chunkStr, "*", "#fe7", msgColor) --yellow
-              end
-              chunkStr = colorWithin(chunkStr, "\\", "#d80", msgColor)  --orange
-            elseif chunkType == "quote" and hasValids and prevType ~= "quote" then
-              chunkStr = "They say something."
-              v['valid'] = true
-              chunkType = "action"
-            end
+                    local pickInd = 0
+                    local newWord = ""
+                    randSource:init(tonumber(byteLC .. wordBytes(word)))
+                    for char in word:gmatch(".") do
+                        local charLower = char:lower()
+                        local isLower = char == charLower
+                        local vowelPattern = mergePattern(vowels)
+                        if charLower:match(vowelPattern) then
+                            local randNum = randSource:randInt(1, #vowels)
+                            char = vowels[randNum]
+                        elseif not char:match("[%p]") then -- Don't mess with punctuation.
+                            local randNum = randSource:randInt(1, #consonants)
+                            char = consonants[randNum]
+                        end
+                        if not isLower then char = char:upper() end
+                        newWord = newWord .. char
+                    end
+                    return newWord
+                end
 
-            --after check, this puts formatted chunks in
-            if chunkType ~= "quote" and prevType == "quote" then
-              local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
+                local function langScramble(str, prof, langCode, msgColor, langColor)
+                    local returnStr = ""
+                    str = str .. " "
+                    str = str:gsub("  ", " ")
+                    local rCount = 0
+                    local words = 0
+                    for i in str:gmatch(".") do
+                        if i == " " then words = words + 1 end
+                    end
+                    words = words + 1
+                    local rMax = words - (words * (prof / 100))
+                    local wordBuffer = ""
+                    local byteLC = wordBytes(langCode)
+                    local iCount = 1
+                    local char
 
-              if not checkCombo:match("[%w%d]") then
-                if prevStr ~= "They say something." then
-                  quoteCombo = "They say something."
+                    if langColor == nil then
+                        local hexDigits =
+                            { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F" }
+                        local randSource = sb.makeRandomSource()
+                        local hexMin = 1
+
+                        --not sure if there's an cleaner way to do this
+                        randSource:init(byteLC .. wordBytes("Red One"))
+                        local rNumR = hexDigits[randSource:randInt(hexMin, 16)]
+                        randSource:init(byteLC .. wordBytes("Green Two"))
+                        local rNumG = hexDigits[randSource:randInt(hexMin, 16)]
+                        randSource:init(byteLC .. wordBytes("Blue Three"))
+                        local rNumB = hexDigits[randSource:randInt(hexMin, 16)]
+                        randSource:init(byteLC .. wordBytes("Red Four"))
+                        local rNumR2 = hexDigits[randSource:randInt(hexMin, 16)]
+                        randSource:init(byteLC .. wordBytes("Green Five"))
+                        local rNumG2 = hexDigits[randSource:randInt(hexMin, 16)]
+                        randSource:init(byteLC .. wordBytes("Blue Six"))
+                        local rNumB2 = hexDigits[randSource:randInt(hexMin, 16)]
+                        langColor = "#" .. rNumR .. rNumG .. rNumB .. rNumR2 .. rNumG2 .. rNumB2
+                    end
+
+                    while iCount <= #str do
+                        char = str:sub(iCount, iCount)
+                        if char == "[" and str:sub(iCount + 3, iCount + 3) == "]" then
+                            returnStr = returnStr .. char .. str:sub(iCount + 1, iCount + 3)
+                            iCount = iCount + 3
+                        elseif char == " " and not wordBuffer:match("%a") and #wordBuffer > 0 then
+                            returnStr = returnStr .. " " .. wordBuffer
+                            wordBuffer = ""
+                        elseif char ~= "'" and char:match("[%s%p]") then
+                            if #wordBuffer > 0 then
+                                local byteWord = wordBytes(wordBuffer)
+                                randSource:init(tonumber(wordBytes(player.uniqueId()) .. byteLC .. byteWord))
+                                local wordRoll = randSource:randInt(1, 100)
+                                if wordRoll > prof then
+                                    wordBuffer = langWordRep(trim(wordBuffer), wordRoll, byteLC)
+                                    wordBuffer = "^" .. langColor .. ";" .. wordBuffer .. "^" .. msgColor .. ";"
+                                    rCount = rCount + 1
+                                end
+                            end
+                            returnStr = returnStr .. wordBuffer .. char
+                            wordBuffer = ""
+                        else
+                            wordBuffer = wordBuffer .. char
+                        end
+                        iCount = iCount + 1
+                    end
+
+                    if returnStr:match("%s", #returnStr) then returnStr = returnStr:sub(0, #returnStr - 1) end
+
+                    randSource:init()
+                    return returnStr
+                end
+
+                local colorTable = { --transparency is an options here, but it makes things hard to read
+                    [-4] = "#555",
+                    [-3] = "#777",
+                    [-2] = "#999",
+                    [-1] = "#bbb",
+                    [0] = "#ddd",
+                    [1] = "#fff",
+                    [2] = "#daa",
+                    [3] = "#d66",
+                    [4] = "#d00",
+                }
+
+                local function colorWithin(str, char, color, prevColor)
+                    local colorOn = false
+                    local charBuffer = ""
+                    for i in str:gmatch(".") do
+                        if i == char then
+                            if colorOn == false then
+                                charBuffer = charBuffer .. "^" .. color .. ";"
+                                colorOn = true
+                            else
+                                charBuffer = charBuffer .. "^" .. prevColor .. ";"
+                                colorOn = false
+                            end
+                        else
+                            --put this outside the if statement to make the characters appear as well as colors
+                            charBuffer = charBuffer .. i
+                        end
+                    end
+                    print("Charbuffer is " .. charBuffer)
+                    return charBuffer
+                end
+
+                local function cleanDoubleSpaces(str)
+                    --run a loop with the string, ignore codes (^whatever;), then remove more than one space in a row
+                    local cleanStr = ""
+                    local iCount = 1
+                    local prevChar = ""
+                    local prevColor = ""
+
+                    while iCount <= #str do
+                        local char = str:sub(iCount, iCount)
+                        local nextSemi = 0
+
+                        if char == "^" then
+                            nextSemi = str:find(";", iCount)
+
+                            if nextSemi ~= nil then
+                                local colorCode = str:sub(iCount, nextSemi)
+                                if colorCode ~= prevColor then cleanStr = cleanStr .. colorCode end
+                                prevColor = colorCode
+                                iCount = nextSemi
+                            end
+                        elseif char ~= " " or prevChar ~= " " then
+                            cleanStr = cleanStr .. char
+                            prevChar = char
+                        end
+                        iCount = iCount + 1
+                    end
+                    cleanStr = cleanStr:gsub("%{ ", "{")
+                    cleanStr = cleanStr:gsub(" %}", "}")
+                    return cleanStr
+                end
+
+                --do visual formatting here.
+                --for dialogue (NOT sounds), start degrading the quality of the message at 50% of the quotes's radius
+                local tableStr = ""
+                local prevStr = ""
+                local quoteCombo = ""
+                local soundCombo = ""
+                local prevType = "action"
+                local quoteOpen = false
+                local soundOpen = false
+                local hasValids = false
+                local chunkStr
+                local chunkType
+                local langBank = {} --populate with languages in inventory when you find them
+                local prevLang = getDefaultLang() --either the player's default language, or !!
+
+                if maxRad ~= -1 and (messageDistance > maxRad and validSum == 0) then
+                    message.text = ""
                 else
-                  quoteCombo = ""
+                    chunkType = nil
+
+                    local prevChunk = ""
+                    local repeatFlag = false
+                    table.insert(textTable, {
+                        text = "",
+                        radius = "0",
+                        type = "bad",
+                        langKey = ":(",
+                        valid = false,
+                        msgQuality = 0,
+                    })
+
+                    for k, v in pairs(textTable) do
+                        if v["hasLOS"] == false and chunkType == "action" then v["valid"] = false end
+                        if v["valid"] then hasValids = true end
+                    end
+                    for k, v in pairs(textTable) do
+                        if v["radius"] == -1 or v["isRadio"] == true then v["valid"] = true end
+
+                        chunkStr = v["text"]
+                        chunkType = v["type"]
+                        local langKey = v["langKey"]
+                        if
+                            v["valid"] == true
+                            or (
+                                chunkType == "quote"
+                                and (
+                                    (k > 1 and textTable[k - 1]["type"] == "quote")
+                                    or (k < #textTable and textTable[k + 1]["type"] == "quote")
+                                )
+                            )
+                        then --check if this is surrounded by quotes
+                            v["valid"] = true --this should be set to true in here, since everything in this block should show up on the screen
+                            -- remember, noiserad is a const and radius is for the message
+
+                            local colorOverride = chunkStr:find("%^%#") ~= nil --don't touch colors if this is true
+                            local actionColor = "#fff" --white for non sound based chunks
+                            local msgColor = "#fff" --white for non sound based chunks
+                            --disguise unheard stuff
+                            if chunkType == "sound" then
+                                if not colorOverride then
+                                    msgColor = colorTable[volTable[v["radius"]]]
+                                    chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                end
+                            elseif chunkType == "quote" then
+                                msgColor = colorTable[volTable[v["radius"]]]
+
+                                if chunkType == "quote" and langKey ~= "!!" then
+                                    local langProf, langColor
+                                    if langBank[langKey] ~= nil then
+                                        langProf = langBank[langKey]["prof"]
+                                        langColor = langBank[langKey]["color"]
+                                    end
+                                    if langProf == nil then
+                                        local receiverIsLocal = isLocalPlayer(receiverEntityId)
+                                        local newLang
+                                        if xsb and receiverIsLocal then
+                                            newLang = world
+                                                .sendEntityMessage(receiverEntityId, "hasLangKey", langKey)
+                                                :result() or nil
+                                        else
+                                            newLang = player.getItemWithParameter("langKey", langKey) or nil
+                                        end
+                                        if newLang then
+                                            langColor = newLang["parameters"]["color"]
+                                            local hasItem
+                                            if xsb and receiverIsLocal then
+                                                hasItem = world
+                                                    .sendEntityMessage(receiverEntityId, "langKeyCount", newLang)
+                                                    :result()
+                                            else
+                                                hasItem = player.hasCountOfItem(newLang, true)
+                                            end
+
+                                            if hasItem then
+                                                langProf = hasItem * 10
+                                            else
+                                                langProf = 0
+                                            end
+                                            langBank[langKey] = {
+                                                prof = langProf,
+                                                color = langColor,
+                                            }
+                                        else
+                                            langProf = 0
+                                        end
+                                    end
+
+                                    if langProf < 100 then
+                                        --scramble the word
+                                        chunkStr = langScramble(trim(chunkStr), langProf, langKey, msgColor, langColor)
+                                    end
+                                end
+                                --check message quality
+                                if v["msgQuality"] < 100 and chunkType == "quote" then
+                                    chunkStr = degradeMessage(trim(chunkStr), v["msgQuality"])
+                                end
+
+                                if not colorOverride then
+                                    chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                end
+
+                                --add in languagee indicator
+                                if langKey ~= prevLang then
+                                    chunkStr = "^#fff;[" .. langKey .. "]^" .. msgColor .. "; " .. chunkStr
+                                    prevLang = langKey
+                                end
+                            end
+                            chunkStr = chunkStr:gsub("%^%#fff%;%^%#fff;", "^#fff;")
+                            chunkStr = chunkStr:gsub("%^" .. msgColor .. ";%^#fff;", "^#fff;")
+                            chunkStr =
+                                chunkStr:gsub("%^" .. msgColor .. ";%^" .. msgColor .. ";", "^" .. msgColor .. ";")
+
+                            --recolors certain things for emphasis
+                            if chunkType ~= "action" then --allow asterisks to stay in actions
+                                chunkStr = colorWithin(chunkStr, "*", "#fe7", msgColor) --yellow
+                            end
+                            chunkStr = colorWithin(chunkStr, "\\", "#d80", msgColor) --orange
+                        elseif chunkType == "quote" and hasValids and prevType ~= "quote" then
+                            chunkStr = "They say something."
+                            v["valid"] = true
+                            chunkType = "action"
+                        end
+
+                        --after check, this puts formatted chunks in
+                        if chunkType ~= "quote" and prevType == "quote" then
+                            local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
+
+                            if not checkCombo:match("[%w%d]") then
+                                if prevStr ~= "They say something." then
+                                    quoteCombo = "They say something."
+                                else
+                                    quoteCombo = ""
+                                end
+                                prevStr = quoteCombo
+                            end
+
+                            quoteCombo = '"' .. quoteCombo .. '"'
+                            tableStr = tableStr .. " " .. quoteCombo
+                            quoteCombo = ""
+                        end
+                        if chunkType ~= "sound" and prevType == "sound" then
+                            if soundCombo:match("[%w%d]") then
+                                soundCombo = "<" .. soundCombo .. ">"
+                                tableStr = tableStr .. " " .. soundCombo
+                            end
+                            soundCombo = ""
+                        end
+
+                        if v["valid"] and chunkType == "quote" then
+                            if quoteCombo:sub(#quoteCombo):match("%p") then
+                                --this adds the space after a quote
+                                quoteCombo = quoteCombo .. " " .. chunkStr
+                            else
+                                quoteCombo = quoteCombo .. chunkStr
+                            end
+                        elseif v["valid"] and chunkType == "sound" then
+                            if soundCombo:sub(#soundCombo):match("%p") then
+                                --this adds the space after a quote
+                                soundCombo = soundCombo .. " " .. chunkStr
+                            else
+                                soundCombo = soundCombo .. chunkStr
+                            end
+                        elseif v["valid"] then --everything that isn't a sound or a quote goes here
+                            tableStr = tableStr .. " " .. chunkStr
+                            prevStr = chunkStr
+                        end
+
+                        prevType = chunkType
+                    end
+                    tableStr = cleanDoubleSpaces(tableStr) --removes double spaces, ignores colors
+                    tableStr = tableStr:gsub(' "%s', ' "')
+                    tableStr = tableStr:gsub("}{", "...") --for multiple radios
+                    tableStr = trim(tableStr)
+
+                    message.text = tableStr
                 end
-                prevStr = quoteCombo
-              end
-
-              quoteCombo = '"' .. quoteCombo .. '"'
-              tableStr = tableStr .. " " .. quoteCombo
-              quoteCombo = ""
             end
-            if chunkType ~= "sound" and prevType == "sound" then
-              if soundCombo:match("[%w%d]") then
-                soundCombo = '<' .. soundCombo .. '>'
-                tableStr = tableStr .. " " .. soundCombo
-              end
-              soundCombo = ""
-            end
-
-            if v['valid'] and chunkType == "quote" then
-              if quoteCombo:sub(#quoteCombo):match("%p") then
-                --this adds the space after a quote
-                quoteCombo = quoteCombo .. " " .. chunkStr
-              else
-                quoteCombo = quoteCombo .. chunkStr
-              end
-            elseif v['valid'] and chunkType == "sound" then
-              if soundCombo:sub(#soundCombo):match("%p") then
-                --this adds the space after a quote
-                soundCombo = soundCombo .. " " .. chunkStr
-              else
-                soundCombo = soundCombo .. chunkStr
-              end
-            elseif v['valid'] then --everything that isn't a sound or a quote goes here
-              tableStr = tableStr .. " " .. chunkStr
-              prevStr = chunkStr
-            end
-
-            prevType = chunkType
-          end
-          tableStr = cleanDoubleSpaces(tableStr) --removes double spaces, ignores colors
-          tableStr = tableStr:gsub(" \"%s", " \"")
-          tableStr = tableStr:gsub("}{", "...")  --for multiple radios
-          tableStr = trim(tableStr)
-
-          message.text = tableStr
         end
-      end
+
+        message.portrait = message.portrait and message.portrait ~= "" and message.portrait or message.connection
     end
 
-    message.portrait = message.portrait and message.portrait ~= "" and message.portrait or message.connection
-  end
-
-  return message
+    return message
 end
 
 function dynamicprox:onReceiveMessage(message) --here for logging the message you receive, just in case you wanted to save it or something
-  if message.connection ~= 0 and message.mode == "Prox" then
-    sb.logInfo("Chat: <%s> %s", message.nickname, message.text)
-  end
+    if message.connection ~= 0 and (message.mode == "Prox" or message.mode == "ProxSecondary") then
+        sb.logInfo("Chat: <%s> %s", message.nickname, message.text)
+    end
 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -878,16 +878,16 @@ function dynamicprox:formatIncomingMessage(message)
                         if rawSub(cInd, cInd + 1) == "[[" then
                             parseDefault("[[")
                             cInd = cInd + 1
+                        elseif rawSub(cInd, cInd + 1) == "[]" then --this should never happen anymore
+                            newMode(curMode)
+                            languageCode = defaultKey
+                            cInd = cInd + 2
                         elseif fStart ~= nil and fEnd ~= nil then
                             local newCode = rawSub(fStart + 1, fEnd)
 
                             if languageCode ~= newCode and curMode == "quote" then newMode(curMode) end
                             languageCode = newCode:upper()
                             cInd = rawText:find("%S", fEnd + 2) or #rawText --set index to the next non whitespace character after the code
-                        elseif rawSub(cInd, cInd + 1) == "[]" then --this should never happen anymore
-                            newMode(curMode)
-                            languageCode = defaultKey
-                            cInd = cInd + 2
                         else
                             parseDefault("[")
                         end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1392,6 +1392,6 @@ end
 
 function dynamicprox:onReceiveMessage(message) --here for logging the message you receive, just in case you wanted to save it or something
     if message.connection ~= 0 and (message.mode == "Prox" or message.mode == "ProxSecondary") then
-        sb.logInfo("Chat: <%s> %s", message.nickname:gsub("%^[^^;];", ""), message.text:gsub("%^[^^;];", ""))
+        sb.logInfo("Chat: <%s> %s", message.nickname:gsub("%^[^^;]-;", ""), message.text:gsub("%^[^^;]-;", ""))
     end
 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -963,6 +963,7 @@ function dynamicprox:formatIncomingMessage(message)
                     for char in word:gmatch(".") do
                         char = char:lower()
                         returnNum = returnNum * 16
+                        if not math.tointeger(returnNum) then returnNum = math.tointeger(2 ^ 48) end
                         returnNum = returnNum + math.abs(string.byte(char) - 100)
                     end
                     return returnNum

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -963,6 +963,7 @@ function dynamicprox:formatIncomingMessage(message)
                     if not type(word) == "string" then return 0 end
                     for char in word:gmatch(".") do
                         char = char:lower()
+                        returnNum = returnNum * 16
                         returnNum = returnNum + math.abs(string.byte(char) - 100)
                     end
                     return returnNum
@@ -1012,7 +1013,7 @@ function dynamicprox:formatIncomingMessage(message)
                     local pickInd = 0
                     local newWord = ""
                     local wordLength = #word
-                    randSource:init(tonumber(byteLC + wordBytes(word)))
+                    randSource:init(byteLC + wordBytes(word))
                     for char in word:gmatch(".") do
                         local charLower = char:lower()
                         local isLower = char == charLower
@@ -1050,6 +1051,10 @@ function dynamicprox:formatIncomingMessage(message)
                     local iCount = 1
                     local char
                     local effProf = 64 * math.log(prof / 3 + 1, 10)
+                    local uniqueIdBytes = wordBytes(
+                        (xsb and isLocalPlayer(receiverEntityId)) and world.entityUniqueId(receiverEntityId)
+                            or player.uniqueId()
+                    )
 
                     if langColor == nil then
                         local hexDigits =
@@ -1087,10 +1092,7 @@ function dynamicprox:formatIncomingMessage(message)
                             if #wordBuffer > 0 then
                                 local wordLength = #wordBuffer
                                 local byteWord = wordBytes(wordBuffer)
-                                local uniqueId = (xsb and isLocalPlayer(receiverEntityId))
-                                        and world.entityUniqueId(receiverEntityId)
-                                    or player.uniqueId()
-                                randSource:init(tonumber(wordBytes(uniqueId) + byteLC + byteWord))
+                                randSource:init(uniqueIdBytes + byteLC + byteWord)
                                 local wordRoll = randSource:randInt(1, 100)
                                 if
                                     effProf < 5

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1512,7 +1512,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                                 end
 
                                 --after check, this puts formatted chunks in
-                                if chunkType ~= "quote" and prevType == "quote" then -- FezzedOne: Fixed bug where quote-only chat messages did not show up in chat.
+                                if chunkType ~= "quote" and prevType == "quote" then
                                     local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
 
                                     if not checkCombo:match("[%w%d]") then
@@ -1522,13 +1522,13 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                                             quoteCombo = ""
                                         end
                                         prevStr = quoteCombo
+                                    else
+                                        quoteCombo = '"' .. quoteCombo .. '"'
                                     end
-
-                                    quoteCombo = '"' .. quoteCombo .. '"'
                                     tableStr = tableStr .. " " .. quoteCombo
                                     quoteCombo = ""
                                 end
-                                if chunkType ~= "sound" and prevType == "sound" then -- FezzedOne: Ditto for sound-only messages.
+                                if chunkType ~= "sound" and prevType == "sound" then
                                     if soundCombo:match("[%w%d]") then
                                         soundCombo = "<" .. soundCombo .. ">"
                                         tableStr = tableStr .. " " .. soundCombo

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1371,14 +1371,17 @@ function dynamicprox:formatIncomingMessage(rawMessage)
 
                             local prevChunk = ""
                             local repeatFlag = false
-                            -- table.insert(textTable, {
-                            --     text = "",
-                            --     radius = "0",
-                            --     type = "bad",
-                            --     langKey = ":(",
-                            --     valid = false,
-                            --     msgQuality = 0,
-                            -- })
+                            table.insert(
+                                textTable,
+                                { -- FezzedOne: Note to self: This dummy chunk is *required* for correct concatenation.
+                                    text = "",
+                                    radius = "0",
+                                    type = "bad",
+                                    langKey = ":(",
+                                    valid = false,
+                                    msgQuality = 0,
+                                }
+                            )
 
                             for _, v in ipairs(textTable) do
                                 if v["hasLOS"] == false and chunkType == "action" then v["valid"] = false end
@@ -1388,7 +1391,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                             end
                             local numChunks = #textTable
                             for k, v in ipairs(textTable) do
-                                local lastChunk = k == #numChunks
+                                local lastChunk = k == numChunks
 
                                 if
                                     v["radius"] == -1
@@ -1509,7 +1512,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                                 end
 
                                 --after check, this puts formatted chunks in
-                                if (chunkType ~= "quote" and prevType == "quote") or lastChunk then -- FezzedOne: Fixed bug where quote-only chat messages did not show up in chat.
+                                if chunkType ~= "quote" and prevType == "quote" then -- FezzedOne: Fixed bug where quote-only chat messages did not show up in chat.
                                     local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
 
                                     if not checkCombo:match("[%w%d]") then
@@ -1525,7 +1528,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                                     tableStr = tableStr .. " " .. quoteCombo
                                     quoteCombo = ""
                                 end
-                                if (chunkType ~= "sound" and prevType == "sound") or lastChunk then -- FezzedOne: Ditto for sound-only messages.
+                                if chunkType ~= "sound" and prevType == "sound" then -- FezzedOne: Ditto for sound-only messages.
                                     if soundCombo:match("[%w%d]") then
                                         soundCombo = "<" .. soundCombo .. ">"
                                         tableStr = tableStr .. " " .. soundCombo

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1,8 +1,29 @@
 require("/interface/scripted/starcustomchat/plugin.lua")
 
+-- Need this to copy message tables.
+local function deepCopy(objectToCopy)
+    local lookup_table = {}
+    local function _copy(object)
+        if type(object) ~= "table" then
+            return object
+        elseif lookup_table[object] then
+            return lookup_table[object]
+        end
+        local new_table = {}
+        lookup_table[object] = new_table
+        for index, value in pairs(object) do
+            new_table[_copy(index)] = _copy(value)
+        end
+        return setmetatable(new_table, _copy(getmetatable(object)))
+    end
+    return _copy(objectToCopy)
+end
+
 dynamicprox = PluginClass:new({
     name = "dynamicprox",
 })
+
+local DynamicProxPrefix = "^DynamicProx,reset;"
 
 -- FezzedOne: From FezzedTech.
 local function rollDice(die) -- From https://github.com/brianherbert/dice/, with modifications.
@@ -118,6 +139,18 @@ function dynamicprox:addCustomCommandPreview(availableCommands, substr)
             description = "commands.showtypos.desc",
             data = "/showtypos",
         })
+    elseif string.find("/proxlocal", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/proxlocal",
+            description = "commands.proxlocal.desc",
+            data = "/proxlocal",
+        })
+    elseif string.find("/sendlocal", substr, nil, true) then
+        table.insert(availableCommands, {
+            name = "/sendlocal",
+            description = "commands.sendlocal.desc",
+            data = "/sendlocal",
+        })
     end
 end
 
@@ -166,6 +199,34 @@ end
 
 --this messagehandler function runs if the chat preview exists
 function dynamicprox:registerMessageHandlers(shared) --look at this function in irden chat's editchat thing
+    starcustomchat.utils.setMessageHandler("/proxlocal", function(_, _, data)
+        if string.lower(data) == "on" then
+            root.setConfiguration("DynamicProxChat::localChatIsProx", true)
+            return "^green;ENABLED^reset; handling local chat as proximity chat"
+        elseif string.lower(data) == "off" then
+            root.setConfiguration("DynamicProxChat::localChatIsProx", false)
+            return "^red;DISABLED^reset; handling local chat as proximity chat"
+        else
+            local enabled = root.getConfiguration("DynamicProxChat::localChatIsProx") or false
+            return "Handling local chat as proximity chat is "
+                .. (enabled and "^green;ENABLED" or "^red;DISABLED")
+                .. "^reset;. To change this setting, pass ^orange;on^reset; or ^orange;off^reset; to this command."
+        end
+    end)
+    starcustomchat.utils.setMessageHandler("/sendlocal", function(_, _, data)
+        if string.lower(data) == "on" then
+            root.setConfiguration("DynamicProxChat::sendProxChatInLocal", true)
+            return "^green;ENABLED^reset; sending proximity chat as local chat"
+        elseif string.lower(data) == "off" then
+            root.setConfiguration("DynamicProxChat::sendProxChatInLocal", false)
+            return "^red;DISABLED^reset; sending proximity chat as local chat"
+        else
+            local enabled = root.getConfiguration("DynamicProxChat::sendProxChatInLocal") or false
+            return "Sending proximity chat as local chat is "
+                .. (enabled and "^green;ENABLED" or "^red;DISABLED")
+                .. "^reset;. To change this setting, pass ^orange;on^reset; or ^orange;off^reset; to this command."
+        end
+    end)
     starcustomchat.utils.setMessageHandler("/showtypos", function(_, _, data)
         local typoTable = player.getProperty("typos", {})
         if typoTable == nil then return "You have no corrections or typos saved. Use /addtypo to make one." end
@@ -435,10 +496,16 @@ function dynamicprox:onSendMessage(data)
                 --     end
                 -- end
 
-                for _, pl in ipairs(players) do
-                    if xsb then data.sourceId = world.primaryPlayer() end
-                    data.targetId = pl -- Add the target player ID so we can filter received messages by target player on the other end on xStarbound clients.
-                    world.sendEntityMessage(pl, "scc_add_message", data)
+                -- FezzedOne: Added a setting that allows proximity chat to be sent as local chat for compatibility with «standard» local chat.
+                -- Chat sent this way is prefixed so that it always shows up as proximity chat for those with the mod installed.
+                if root.getConfiguration("DynamicProxChat::sendProxChatInLocal") then
+                    chat.send(DynamicProxPrefix .. data.content, "Local", false)
+                else
+                    for _, pl in ipairs(players) do
+                        if xsb then data.sourceId = world.primaryPlayer() end
+                        data.targetId = pl -- Add the target player ID so we can filter received messages by target player on the other end on xStarbound clients.
+                        world.sendEntityMessage(pl, "scc_add_message", data)
+                    end
                 end
                 if #globalStrings ~= 0 then
                     local globalMsg = ""
@@ -448,6 +515,7 @@ function dynamicprox:onSendMessage(data)
                     globalMsg:sub(1, -2)
                     globalMsg = "{{" .. globalMsg .. "}}"
                     globalMsg = globalMsg:gsub("[ ]+", " "):gsub("%{ ", "{"):gsub(" %}", "}")
+                    globalMsg = DynamicProxPrefix .. globalMsg
                     -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
                     chat.send(globalMsg, "Broadcast", false)
                 end
@@ -459,6 +527,7 @@ function dynamicprox:onSendMessage(data)
                     globalOocMsg:sub(1, -2)
                     globalOocMsg = "((" .. globalOocMsg .. "))"
                     globalOocMsg = globalOocMsg:gsub("[ ]+", " ")
+                    globalOocMsg = DynamicProxPrefix .. globalOocMsg
                     -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
                     chat.send(globalOocMsg, "Broadcast", false)
                 end
@@ -477,10 +546,15 @@ function dynamicprox:onSendMessage(data)
 end
 
 function dynamicprox:formatIncomingMessage(message)
-    --think about running this in local to allow players without the mod to still see messages
-
-    if message.mode == "Prox" then
-        message.text = message.content
+    local hasPrefix = message.text:sub(1, #DynamicProxPrefix) == DynamicProxPrefix
+    -- FezzedOne: Added a setting that allows local chat to be «funneled» into proximity chat and appropriately formatted and filtered automatically.
+    if hasPrefix or (root.getConfiguration("DynamicProxChat::localChatIsProx") and message.mode == "Local") then
+        message.mode = "Prox"
+        if hasPrefix and not message.processed then message.text = message.text:sub(#DynamicProxPrefix + 1, -1) end
+        message.contentIsText = true
+    end
+    if message.mode == "Prox" and not message.processed then
+        if not message.contentIsText then message.text = message.content end
         message.content = ""
 
         if message.connection then --i don't know what receivingRestricted does
@@ -495,896 +569,925 @@ function dynamicprox:formatIncomingMessage(message)
                 end
                 return false
             end
-            if xsb then
-                if message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
-                    local receiverName = world.entityName(receiverEntityId)
-                    if #ownPlayers ~= 1 then message.nickname = message.nickname .. " -> " .. receiverName end
-                    if message.targetId ~= player.id() then message.mode = "ProxSecondary" end
+            local authorRendered = world.entityExists(authorEntityId)
+
+            local handleMessage = function(receiverEntityId, copiedMessage)
+                local message = copiedMessage or message
+                if xsb then
+                    if copiedMessage or message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
+                        local receiverName = world.entityName(receiverEntityId)
+                        if #ownPlayers ~= 1 then message.nickname = message.nickname .. " -> " .. receiverName end
+                        if receiverEntityId ~= player.id() then message.mode = "ProxSecondary" end
+                    end
                 end
-            end
-
-            if world.entityExists(authorEntityId) then
-                local authorPos = world.entityPosition(authorEntityId)
-                local playerPos =
-                    world.entityPosition(world.entityExists(receiverEntityId) and receiverEntityId or player.id())
-                local messageDistance = world.magnitude(playerPos, authorPos)
-                -- messageDistance = 30
-                local inSight = not world.lineTileCollision(authorPos, playerPos, { "Block", "Dynamic" }) --not doing dynamic, i think that's only for open doors
-
-                -- this is for later, testing to see if i can calculate how many tiles are between a sender and receiver
-                -- local testCol = world.lineTileCollisionPoint(authorPos, playerPos, { "Block", "Dynamic" })
-                -- sb.logWarn("messageDistance is " .. messageDistance)
-                -- if testCol ~= nil then
-                --   sb.logInfo("testCol is " .. dump(testCol))
-                --   local pos1 = testCol[1][1]
-                --   local pos2 = testCol[1][2]
-                --   sb.logInfo("pos1 "..pos1.." pos2 "..pos2)
-                --   sb.logInfo("distance is " .. world.magnitude(pos1, pos2))
-                -- end
-                local randSource = sb.makeRandomSource()
-
-                local actionRad = self.proxActionRadius -- FezzedOne: Un-hardcoded the action radius.
-                local loocRad = self.proxOocRadius -- actionRad * 2 -- FezzedOne: Un-hardcoded the local OOC radius.
-                local noiseRad = self.proxTalkRadius -- FezzedOne: Un-hardcoded the talking radius.
-
-                --originally i made this a function, but tracking the values is difficult and it's easier to manually set them since there are only 9
-                local soundTable = {
-                    [-4] = noiseRad / 10,
-                    [-3] = noiseRad / 5,
-                    [-2] = noiseRad / 4,
-                    [-1] = noiseRad / 2,
-                    [0] = noiseRad, --based on the default range of talking being 50, this should be good
-                    [1] = noiseRad * 1.5,
-                    [2] = noiseRad * 2,
-                    [3] = noiseRad * 3,
-                    [4] = noiseRad * 5,
-                }
-
-                --i dont like this but it'll have to do
-                local volTable = {
-                    [noiseRad / 10] = -4,
-                    [noiseRad / 5] = -3,
-                    [noiseRad / 4] = -2,
-                    [noiseRad / 2] = -1,
-                    [noiseRad] = 0, --based on the default range of talking being 50, this should be good
-                    [noiseRad * 1.5] = 1,
-                    [noiseRad * 2] = 2,
-                    [noiseRad * 3] = 3,
-                    [noiseRad * 5] = 4,
-                }
-
-                local tVol, sVol = 0, 0
-                local tVolRad = noiseRad
-                local sVolRad = noiseRad
-                --iterate through message and get components here
-                local curMode = "action"
-                local prevMode = "action"
-                local prevDiffMode = "action"
-                local maxRad = 0
-                local rawText = message.text
-                local debugTable = {} --this will eventually be smashed together to make filterText
-                local textTable = {} --this will eventually be smashed together to make filterText
-                local validSum = 0 --number of valid entries in the table
-                local cInd = 1 --lua starts at 1 >:(
-                local charBuffer = ""
-                local languageCode = message.defaultLang --the !! shouldn't need to be set, but i'll leave it anyway
-                local radioMode = false --radio flag
-
-                local modeRadTypes = {
-                    action = function() return actionRad end,
-                    quote = function() return tVolRad end,
-                    sound = function() return sVolRad end,
-                    lOOC = function() return loocRad end,
-                    gOOC = function() return -1 end,
-                }
-
-                local function rawSub(sInd, eInd) return rawText:sub(sInd, eInd) end
-
-                --use this to construct the components
-                --any component indications (like :+) that remain should stay, use them for coloring if they aren't picked up here and reset after each component
-                local function formatInsert(str, radius, type, langKey, isValid, msgQuality, inSight, isRadio)
-                    if langKey == nil then langKey = "!!" end
-
-                    if msgQuality < 0 then msgQuality = 100 end
-
-                    table.insert(textTable, {
-                        text = str,
-                        radius = radius,
-                        type = type,
-                        langKey = langKey,
-                        valid = isValid,
-                        msgQuality = msgQuality,
-                        hasLOS = inSight,
-                        isRadio = isRadio,
-                    })
-                end
-
-                local function parseDefault(letter)
-                    charBuffer = charBuffer .. letter
-                    cInd = cInd + 1
-                end
-
-                local function newMode(nextMode) --if radius is -1, the insert is instance wide
-                    if #charBuffer < 1 or charBuffer == '"' or charBuffer == ">" or charBuffer == "<" then
-                        prevMode = curMode
-                        curMode = nextMode
-                        return
+                if message.contentIsText or world.entityExists(authorEntityId) then
+                    local authorPos, messageDistance, inSight = nil, math.huge, false
+                    local playerPos =
+                        world.entityPosition(world.entityExists(receiverEntityId) and receiverEntityId or player.id())
+                    if authorRendered then
+                        authorPos = world.entityPosition(authorEntityId)
+                        messageDistance = world.magnitude(playerPos, authorPos)
+                        -- messageDistance = 30
+                        inSight = not world.lineTileCollision(authorPos, playerPos, { "Block", "Dynamic" }) --not doing dynamic, i think that's only for open doors
                     end
 
-                    local useRad
-                    useRad = modeRadTypes[curMode]()
-                    local isValid = false --start with false
-                    if messageDistance <= useRad or useRad == -1 then --if in range
-                        isValid = true --the message is valid
-                        if inSight == false and curMode == "action" then --if i can't see you and the mode is action
-                            isValid = false --the message isn't valid anymore
-                        elseif inSight == false and (curMode == "quote" or curMode == "sound") then --else, if i can't see you and the mode is quote or sound
-                            --check for path
-                            local noPathVol
-                            if
-                                world.findPlatformerPath(
-                                    authorPos,
-                                    playerPos,
-                                    root.monsterMovementSettings("smallflying")
-                                )
-                            then --if path is found
-                                noPathVol = volTable[useRad] - 1 --set the volume to 1 (maybe 2 later on) level lower
-                            else --if the path isn't found
-                                noPathVol = volTable[useRad] - 4 --set the volume to 4 levels lower
-                            end
-                            if noPathVol > 4 then
-                                noPathVol = 4
-                            elseif noPathVol < -4 then
-                                noPathVol = -4
-                                isValid = false
-                            end
-                            useRad = soundTable[noPathVol] --set the radius to whatever the soundelevel would be
-                            isValid = isValid and messageDistance <= useRad --set isvalid to the new value if it's still true
-                        end
+                    -- this is for later, testing to see if i can calculate how many tiles are between a sender and receiver
+                    -- local testCol = world.lineTileCollisionPoint(authorPos, playerPos, { "Block", "Dynamic" })
+                    -- sb.logWarn("messageDistance is " .. messageDistance)
+                    -- if testCol ~= nil then
+                    --   sb.logInfo("testCol is " .. dump(testCol))
+                    --   local pos1 = testCol[1][1]
+                    --   local pos2 = testCol[1][2]
+                    --   sb.logInfo("pos1 "..pos1.." pos2 "..pos2)
+                    --   sb.logInfo("distance is " .. world.magnitude(pos1, pos2))
+                    -- end
+                    local randSource = sb.makeRandomSource()
+
+                    local actionRad = self.proxActionRadius -- FezzedOne: Un-hardcoded the action radius.
+                    local loocRad = self.proxOocRadius -- actionRad * 2 -- FezzedOne: Un-hardcoded the local OOC radius.
+                    local noiseRad = self.proxTalkRadius -- FezzedOne: Un-hardcoded the talking radius.
+
+                    --originally i made this a function, but tracking the values is difficult and it's easier to manually set them since there are only 9
+                    local soundTable = {
+                        [-4] = noiseRad / 10,
+                        [-3] = noiseRad / 5,
+                        [-2] = noiseRad / 4,
+                        [-1] = noiseRad / 2,
+                        [0] = noiseRad, --based on the default range of talking being 50, this should be good
+                        [1] = noiseRad * 1.5,
+                        [2] = noiseRad * 2,
+                        [3] = noiseRad * 3,
+                        [4] = noiseRad * 5,
+                    }
+
+                    --i dont like this but it'll have to do
+                    local volTable = {
+                        [noiseRad / 10] = -4,
+                        [noiseRad / 5] = -3,
+                        [noiseRad / 4] = -2,
+                        [noiseRad / 2] = -1,
+                        [noiseRad] = 0, --based on the default range of talking being 50, this should be good
+                        [noiseRad * 1.5] = 1,
+                        [noiseRad * 2] = 2,
+                        [noiseRad * 3] = 3,
+                        [noiseRad * 5] = 4,
+                    }
+
+                    local tVol, sVol = 0, 0
+                    local tVolRad = noiseRad
+                    local sVolRad = noiseRad
+                    --iterate through message and get components here
+                    local curMode = "action"
+                    local prevMode = "action"
+                    local prevDiffMode = "action"
+                    local maxRad = 0
+                    local rawText = message.text
+                    local debugTable = {} --this will eventually be smashed together to make filterText
+                    local textTable = {} --this will eventually be smashed together to make filterText
+                    local validSum = 0 --number of valid entries in the table
+                    local cInd = 1 --lua starts at 1 >:(
+                    local charBuffer = ""
+                    local languageCode = message.defaultLang --the !! shouldn't need to be set, but i'll leave it anyway
+                    local radioMode = false --radio flag
+
+                    local modeRadTypes = {
+                        action = function() return actionRad end,
+                        quote = function() return tVolRad end,
+                        sound = function() return sVolRad end,
+                        lOOC = function() return loocRad end,
+                        gOOC = function() return -1 end,
+                    }
+
+                    local function rawSub(sInd, eInd) return rawText:sub(sInd, eInd) end
+
+                    --use this to construct the components
+                    --any component indications (like :+) that remain should stay, use them for coloring if they aren't picked up here and reset after each component
+                    local function formatInsert(str, radius, type, langKey, isValid, msgQuality, inSight, isRadio)
+                        if langKey == nil then langKey = "!!" end
+
+                        if msgQuality < 0 then msgQuality = 100 end
+
+                        table.insert(textTable, {
+                            text = str,
+                            radius = radius,
+                            type = type,
+                            langKey = langKey,
+                            valid = isValid,
+                            msgQuality = msgQuality,
+                            hasLOS = inSight,
+                            isRadio = isRadio,
+                        })
                     end
 
-                    local msgQuality = 0
-                    if isValid then
-                        validSum = validSum + 1
-                        msgQuality = math.min(((useRad / 2) / messageDistance) * 100, 100) --basically, check half the radius and take the percentage of that vs the message distance, cap at 100
-                        maxRad = math.max(maxRad, useRad)
-                    end
-
-                    if useRad == -1 and maxRad ~= -1 then maxRad = -1 end
-                    formatInsert(charBuffer, useRad, curMode, languageCode, isValid, msgQuality, inSight, radioMode)
-                    charBuffer = ""
-
-                    prevMode = curMode
-                    if curMode ~= nextMode then prevDiffMode = curMode end
-                    curMode = nextMode
-                end
-
-                local defaultKey = getDefaultLang()
-
-                local mode_table = {
-                    ['"'] = function()
-                        if curMode == "quote" then
-                            parseDefault("")
-                            newMode("action")
-                        elseif curMode == "action" then
-                            newMode("quote")
-                            parseDefault("")
-                        else
-                            parseDefault('"')
-                        end
-                    end,
-                    ["<"] = function() --i could combine these two, but i don't want to
-                        if curMode ~= "sound" and curMode ~= "quote" then --added quotes here so people can do the cool combine vocoder thing <::Pick up that can.::>
-                            newMode("sound")
-                        end
-                        parseDefault("")
-                    end,
-                    [">"] = function()
-                        parseDefault("")
-                        if curMode == "sound" then newMode(prevDiffMode) end
-                    end,
-                    [":"] = function()
-                        local nextChar = rawSub(cInd + 1, cInd + 1)
-                        if nextChar == "+" or nextChar == "-" or nextChar == "=" then
-                            newMode(curMode) --this happens to change volume, but mode isn't actually changing
-
-                            local maxAmp = 4 --maximum chars after the colon
-
-                            local lStart, lEnd = rawText:find(":%++", cInd)
-                            local qStart, qEnd = rawText:find(":%-+", cInd)
-                            local eStart, eEnd = rawText:find(":%=+", cInd)
-                            local nCStart, nCEnd
-
-                            if qStart == nil then qStart = #rawText end
-                            if qEnd == nil then qEnd = #rawText end
-                            if lStart == nil then lStart = #rawText end
-                            if lEnd == nil then lEnd = #rawText end
-                            if eStart == nil then eStart = #rawText end
-                            if eEnd == nil then eEnd = #rawText end
-
-                            if math.min(eStart, lStart, qStart) == eStart then
-                                nCStart = eStart
-                                nCEnd = eEnd
-                            elseif math.min(eStart, lStart, qStart) == lStart then
-                                nCStart = lStart
-                                nCEnd = lEnd
-                            elseif math.min(eStart, lStart, qStart) == qStart then
-                                nCStart = qStart
-                                nCEnd = qEnd
-                            end
-
-                            local doVolume = "none"
-                            --in these modes, ignore the volume controls
-                            if curMode == "radio" or curMode == "gOOC" or curMode == "lOOC" then
-                                cInd = nCEnd + 1
-                            elseif curMode == "action" then
-                                local nextInd = rawText:find('["<]', cInd)
-
-                                if nextChar == nil then --if they just put this at the end for some reason
-                                    cInd = nCEnd + 1
-                                elseif nextInd ~= nil then
-                                    nextChar = rawSub(nextInd, nextInd)
-                                end
-                                if nextChar == '"' then
-                                    doVolume = "quote"
-                                else
-                                    doVolume = "sound"
-                                end
-                            else
-                                doVolume = curMode
-                            end
-
-                            if doVolume ~= "none" then
-                                local sum = 0
-                                local nextStr = rawSub(nCStart + 1, nCEnd)
-
-                                if doVolume == "quote" then
-                                    sum = tVol
-                                else
-                                    sum = sVol
-                                end
-
-                                for i in nextStr:gmatch(".") do
-                                    if i == "+" then
-                                        sum = sum + 1
-                                    elseif i == "-" then
-                                        sum = sum - 1
-                                    elseif i == "=" then
-                                        sum = 0
-                                        if doVolume == "quote" then
-                                            tVolRad = noiseRad
-                                        else
-                                            sVolRad = noiseRad
-                                        end
-                                    end
-                                end
-                                cInd = nCEnd
-
-                                sum = math.min(math.max(sum, -4), 4)
-
-                                if doVolume == "quote" then
-                                    tVol = sum
-                                    tVolRad = soundTable[sum]
-                                else
-                                    sVol = sum
-                                    sVolRad = soundTable[sum]
-                                end
-                            end
-                            cInd = nCEnd + 1
-                        else
-                            parseDefault(":")
-                        end
-                    end,
-                    ["*"] = function() --leave this for the visual alterations later on
-                        -- i have this commented out so people can keep asterisks in actions if they want
-                        -- if curMode == 'action' then
-                        --   cInd = cInd + 1
-                        -- else
-                        --   parseDefault("*")
-                        -- end
-                        parseDefault("*")
-                    end,
-                    ["/"] = function() parseDefault("/") end,
-                    ["`"] = function() parseDefault("`") end,
-                    ["\\"] = function() -- Allow escaping any specially parsed character with `\`.
-                        local nextChar = rawSub(cInd + 1, cInd + 1)
-                        parseDefault(nextChar)
-                        cInd = cInd + 1
-                    end,
-                    ["("] = function() --check for number of parentheses
-                        local nextChar = rawSub(cInd + 1, cInd + 1)
-                        if nextChar == "(" then
-                            local oocEnd = 0
-                            local oocBump = 0
-                            local oocType
-                            local oocRad
-                            if rawSub(cInd + 2, cInd + 2) == "(" then
-                                --global ooc
-                                _, oocEnd = rawText:find("%)%)%)+", cInd) --the + catches extra parentheses in case someone adds more than 3
-                                oocType = "gOOC"
-                                oocBump = 2
-                                oocRad = -1
-                            else
-                                --local ooc
-                                _, oocEnd = rawText:find("%)%)+", cInd)
-                                oocBump = 1
-                                oocType = "lOOC"
-                                oocRad = actionRad * 2
-                            end
-
-                            if oocEnd ~= nil then
-                                newMode(oocType)
-                                charBuffer = charBuffer .. rawSub(cInd, oocEnd)
-                                newMode(prevMode)
-                            else
-                                charBuffer = charBuffer .. rawSub(cInd, cInd + oocBump)
-                                cInd = cInd + oocBump
-                                oocEnd = cInd
-                            end
-
-                            cInd = oocEnd + 1
-                        else
-                            parseDefault("(")
-                        end
-                    end,
-                    ["{"] = function() --this should function as a global IC message, but finding the playercount is not possible (or i'm stupid) clientside
-                        --i'm not doing secure radio because you can edit this file and ignore the password requirement with it
-                        --if you want to do that, just do it over group chat or something
-                        --this is where a stagehand serverside would be useful. In the future it might be worth exploring that
-
-                        --maybe set up multiple radio ranges with multiple brackets? seems kind of pointless imo
-                        newMode(curMode)
-                        radioMode = true
-                        parseDefault("{")
-                    end,
-                    ["}"] = function()
-                        if rawSub(cInd + 1, cInd + 1) == '"' and curMode == "quote" then
-                            parseDefault("}")
-                            parseDefault('"')
-                            newMode("action")
-                        else
-                            parseDefault("}")
-                            newMode(curMode)
-                        end
-
-                        radioMode = false
-                        -- cInd = cInd + 1
-                    end,
-                    -- ["|"] = function()
-                    --     local fStart = cInd
-                    --     local fEnd = rawText:find("|", cInd + 1)
-                    --
-                    --     if fStart ~= nil and fEnd ~= nil then
-                    --         -- local timeNum = tostring(math.floor(os.time()))
-                    --         -- local mixNum = tonumber(timeNum .. math.abs(authorEntityId))
-                    --         -- randSource:init(mixNum)
-                    --         -- local numMax = rawSub(fStart, fEnd - 1):gsub("%D", "")
-                    --         -- local roll = randSource:randInt(1, tonumber(numMax) or 20)
-                    --         -- FezzedOne: Replaced dice roller with the more flexible one from FezzedTech.
-                    --         local diceResults = rawSub(fStart + 1, fEnd):gsub("[ ]*", ""):gsub(
-                    --             "(.-)[,|]",
-                    --             function(die) return tostring(rollDice(die) or "n/a") .. ", " end
-                    --         )
-                    --         parseDefault("|" .. diceResults:sub(1, -3) .. "|")
-                    --         cInd = fEnd + 1
-                    --     else
-                    --         parseDefault("|")
-                    --     end
-                    -- end,
-                    ["["] = function()
-                        -- FezzedOne: Added escape code handling.
-                        local fStart = cInd
-                        local fEnd = rawText:find("[^\\]%]", cInd + 1)
-                        if rawSub(cInd, cInd + 1) == "[[" then
-                            parseDefault("[[")
-                            cInd = cInd + 1
-                        elseif rawSub(cInd, cInd + 1) == "[]" then --this should never happen anymore
-                            newMode(curMode)
-                            languageCode = defaultKey
-                            cInd = cInd + 2
-                        elseif fStart ~= nil and fEnd ~= nil then
-                            local newCode = rawSub(fStart + 1, fEnd)
-
-                            if languageCode ~= newCode and curMode == "quote" then newMode(curMode) end
-                            languageCode = newCode:upper()
-                            cInd = rawText:find("%S", fEnd + 2) or #rawText --set index to the next non whitespace character after the code
-                        else
-                            parseDefault("[")
-                        end
-                    end,
-                    default = function(letter)
+                    local function parseDefault(letter)
                         charBuffer = charBuffer .. letter
                         cInd = cInd + 1
-                    end,
-                }
-
-                local c
-
-                --run this loop to generate textTable, then concatenate
-                while cInd <= #rawText do
-                    c = rawSub(cInd, cInd)
-
-                    if mode_table[c] then
-                        mode_table[c]()
-                    else
-                        parseDefault(c)
                     end
-                end
-                newMode(curMode) --makes sure nothing is left out
 
-                local function trim(s)
-                    local l = 1
-                    while string.sub(s, l, l) == " " do
-                        l = l + 1
-                    end
-                    local r = #s
-                    while string.sub(s, r, r) == " " do
-                        r = r - 1
-                    end
-                    return string.sub(s, l, r)
-                end
+                    local function newMode(nextMode) --if radius is -1, the insert is instance wide
+                        if #charBuffer < 1 or charBuffer == '"' or charBuffer == ">" or charBuffer == "<" then
+                            prevMode = curMode
+                            curMode = nextMode
+                            return
+                        end
 
-                local function degradeMessage(str, quality)
-                    local returnStr = ""
-                    local char
-                    local iCount = 1
-                    local rMax = (#str - 2) - ((#str - 2) * (quality / 100)) --basically, how many characters can be "-", helps
-                    local rCount = 0
-                    while iCount <= #str do
-                        char = str:sub(iCount, iCount)
-                        if char == "\\" then
-                            returnStr = returnStr .. str:sub(iCount + 1, iCount + 1)
-                            iCount = iCount + 2
-                        -- FezzedOne: Got rid of hardcoded assumption that language codes are two characters long.
-                        elseif char == "[" and str:find("]", iCount) ~= nil then
-                            local closingBracket = str:find("]", iCount)
-                            returnStr = returnStr .. str:sub(iCount, closingBracket)
-                            iCount = closingBracket + 1
-                        elseif char == "^" and str:find(";", iCount) ~= nil then
-                            local nextSemi = str:find(";", iCount)
-                            returnStr = returnStr .. str:sub(iCount, nextSemi)
-                            iCount = nextSemi + 1
+                        local useRad
+                        useRad = modeRadTypes[curMode]()
+                        local isValid = false --start with false
+                        if messageDistance <= useRad or useRad == -1 then --if in range
+                            isValid = true --the message is valid
+                            if inSight == false and curMode == "action" then --if i can't see you and the mode is action
+                                isValid = false --the message isn't valid anymore
+                            elseif inSight == false and (curMode == "quote" or curMode == "sound") then --else, if i can't see you and the mode is quote or sound
+                                --check for path
+                                local noPathVol
+                                if authorPos then
+                                    if
+                                        world.findPlatformerPath(
+                                            authorPos,
+                                            playerPos,
+                                            root.monsterMovementSettings("smallflying")
+                                        )
+                                    then --if path is found
+                                        noPathVol = volTable[useRad] - 1 --set the volume to 1 (maybe 2 later on) level lower
+                                    else --if the path isn't found
+                                        noPathVol = volTable[useRad] - 4 --set the volume to 4 levels lower
+                                    end
+                                else
+                                    noPathVol = -4
+                                end
+                                if noPathVol > 4 then
+                                    noPathVol = 4
+                                elseif noPathVol < -4 then
+                                    noPathVol = -4
+                                    isValid = false
+                                end
+                                useRad = soundTable[noPathVol] --set the radius to whatever the soundelevel would be
+                                isValid = isValid and messageDistance <= useRad --set isvalid to the new value if it's still true
+                            end
+                        end
+
+                        local msgQuality = 0
+                        if isValid then
+                            validSum = validSum + 1
+                            msgQuality = math.min(((useRad / 2) / messageDistance) * 100, 100) --basically, check half the radius and take the percentage of that vs the message distance, cap at 100
+                            maxRad = math.max(maxRad, useRad)
+                        end
+
+                        if useRad == -1 and maxRad ~= -1 then maxRad = -1 end
+                        formatInsert(charBuffer, useRad, curMode, languageCode, isValid, msgQuality, inSight, radioMode)
+                        charBuffer = ""
+
+                        prevMode = curMode
+                        if curMode ~= nextMode then prevDiffMode = curMode end
+                        curMode = nextMode
+                    end
+
+                    local defaultKey = getDefaultLang()
+
+                    local mode_table = {
+                        ['"'] = function()
+                            if curMode == "quote" then
+                                parseDefault("")
+                                newMode("action")
+                            elseif curMode == "action" then
+                                newMode("quote")
+                                parseDefault("")
+                            else
+                                parseDefault('"')
+                            end
+                        end,
+                        ["<"] = function() --i could combine these two, but i don't want to
+                            if curMode ~= "sound" and curMode ~= "quote" then --added quotes here so people can do the cool combine vocoder thing <::Pick up that can.::>
+                                newMode("sound")
+                            end
+                            parseDefault("")
+                        end,
+                        [">"] = function()
+                            parseDefault("")
+                            if curMode == "sound" then newMode(prevDiffMode) end
+                        end,
+                        [":"] = function()
+                            local nextChar = rawSub(cInd + 1, cInd + 1)
+                            if nextChar == "+" or nextChar == "-" or nextChar == "=" then
+                                newMode(curMode) --this happens to change volume, but mode isn't actually changing
+
+                                local maxAmp = 4 --maximum chars after the colon
+
+                                local lStart, lEnd = rawText:find(":%++", cInd)
+                                local qStart, qEnd = rawText:find(":%-+", cInd)
+                                local eStart, eEnd = rawText:find(":%=+", cInd)
+                                local nCStart, nCEnd
+
+                                if qStart == nil then qStart = #rawText end
+                                if qEnd == nil then qEnd = #rawText end
+                                if lStart == nil then lStart = #rawText end
+                                if lEnd == nil then lEnd = #rawText end
+                                if eStart == nil then eStart = #rawText end
+                                if eEnd == nil then eEnd = #rawText end
+
+                                if math.min(eStart, lStart, qStart) == eStart then
+                                    nCStart = eStart
+                                    nCEnd = eEnd
+                                elseif math.min(eStart, lStart, qStart) == lStart then
+                                    nCStart = lStart
+                                    nCEnd = lEnd
+                                elseif math.min(eStart, lStart, qStart) == qStart then
+                                    nCStart = qStart
+                                    nCEnd = qEnd
+                                end
+
+                                local doVolume = "none"
+                                --in these modes, ignore the volume controls
+                                if curMode == "radio" or curMode == "gOOC" or curMode == "lOOC" then
+                                    cInd = nCEnd + 1
+                                elseif curMode == "action" then
+                                    local nextInd = rawText:find('["<]', cInd)
+
+                                    if nextChar == nil then --if they just put this at the end for some reason
+                                        cInd = nCEnd + 1
+                                    elseif nextInd ~= nil then
+                                        nextChar = rawSub(nextInd, nextInd)
+                                    end
+                                    if nextChar == '"' then
+                                        doVolume = "quote"
+                                    else
+                                        doVolume = "sound"
+                                    end
+                                else
+                                    doVolume = curMode
+                                end
+
+                                if doVolume ~= "none" then
+                                    local sum = 0
+                                    local nextStr = rawSub(nCStart + 1, nCEnd)
+
+                                    if doVolume == "quote" then
+                                        sum = tVol
+                                    else
+                                        sum = sVol
+                                    end
+
+                                    for i in nextStr:gmatch(".") do
+                                        if i == "+" then
+                                            sum = sum + 1
+                                        elseif i == "-" then
+                                            sum = sum - 1
+                                        elseif i == "=" then
+                                            sum = 0
+                                            if doVolume == "quote" then
+                                                tVolRad = noiseRad
+                                            else
+                                                sVolRad = noiseRad
+                                            end
+                                        end
+                                    end
+                                    cInd = nCEnd
+
+                                    sum = math.min(math.max(sum, -4), 4)
+
+                                    if doVolume == "quote" then
+                                        tVol = sum
+                                        tVolRad = soundTable[sum]
+                                    else
+                                        sVol = sum
+                                        sVolRad = soundTable[sum]
+                                    end
+                                end
+                                cInd = nCEnd + 1
+                            else
+                                parseDefault(":")
+                            end
+                        end,
+                        ["*"] = function() --leave this for the visual alterations later on
+                            -- i have this commented out so people can keep asterisks in actions if they want
+                            -- if curMode == 'action' then
+                            --   cInd = cInd + 1
+                            -- else
+                            --   parseDefault("*")
+                            -- end
+                            parseDefault("*")
+                        end,
+                        ["/"] = function() parseDefault("/") end,
+                        ["`"] = function() parseDefault("`") end,
+                        ["\\"] = function() -- Allow escaping any specially parsed character with `\`.
+                            local nextChar = rawSub(cInd + 1, cInd + 1)
+                            parseDefault(nextChar)
+                            cInd = cInd + 1
+                        end,
+                        ["("] = function() --check for number of parentheses
+                            local nextChar = rawSub(cInd + 1, cInd + 1)
+                            if nextChar == "(" then
+                                local oocEnd = 0
+                                local oocBump = 0
+                                local oocType
+                                local oocRad
+                                if rawSub(cInd + 2, cInd + 2) == "(" then
+                                    --global ooc
+                                    _, oocEnd = rawText:find("%)%)%)+", cInd) --the + catches extra parentheses in case someone adds more than 3
+                                    oocType = "gOOC"
+                                    oocBump = 2
+                                    oocRad = -1
+                                else
+                                    --local ooc
+                                    _, oocEnd = rawText:find("%)%)+", cInd)
+                                    oocBump = 1
+                                    oocType = "lOOC"
+                                    oocRad = actionRad * 2
+                                end
+
+                                if oocEnd ~= nil then
+                                    newMode(oocType)
+                                    charBuffer = charBuffer .. rawSub(cInd, oocEnd)
+                                    newMode(prevMode)
+                                else
+                                    charBuffer = charBuffer .. rawSub(cInd, cInd + oocBump)
+                                    cInd = cInd + oocBump
+                                    oocEnd = cInd
+                                end
+
+                                cInd = oocEnd + 1
+                            else
+                                parseDefault("(")
+                            end
+                        end,
+                        ["{"] = function() --this should function as a global IC message, but finding the playercount is not possible (or i'm stupid) clientside
+                            --i'm not doing secure radio because you can edit this file and ignore the password requirement with it
+                            --if you want to do that, just do it over group chat or something
+                            --this is where a stagehand serverside would be useful. In the future it might be worth exploring that
+
+                            --maybe set up multiple radio ranges with multiple brackets? seems kind of pointless imo
+                            newMode(curMode)
+                            radioMode = true
+                            parseDefault("{")
+                        end,
+                        ["}"] = function()
+                            if rawSub(cInd + 1, cInd + 1) == '"' and curMode == "quote" then
+                                parseDefault("}")
+                                parseDefault('"')
+                                newMode("action")
+                            else
+                                parseDefault("}")
+                                newMode(curMode)
+                            end
+
+                            radioMode = false
+                            -- cInd = cInd + 1
+                        end,
+                        -- ["|"] = function()
+                        --     local fStart = cInd
+                        --     local fEnd = rawText:find("|", cInd + 1)
+                        --
+                        --     if fStart ~= nil and fEnd ~= nil then
+                        --         -- local timeNum = tostring(math.floor(os.time()))
+                        --         -- local mixNum = tonumber(timeNum .. math.abs(authorEntityId))
+                        --         -- randSource:init(mixNum)
+                        --         -- local numMax = rawSub(fStart, fEnd - 1):gsub("%D", "")
+                        --         -- local roll = randSource:randInt(1, tonumber(numMax) or 20)
+                        --         -- FezzedOne: Replaced dice roller with the more flexible one from FezzedTech.
+                        --         local diceResults = rawSub(fStart + 1, fEnd):gsub("[ ]*", ""):gsub(
+                        --             "(.-)[,|]",
+                        --             function(die) return tostring(rollDice(die) or "n/a") .. ", " end
+                        --         )
+                        --         parseDefault("|" .. diceResults:sub(1, -3) .. "|")
+                        --         cInd = fEnd + 1
+                        --     else
+                        --         parseDefault("|")
+                        --     end
+                        -- end,
+                        ["["] = function()
+                            -- FezzedOne: Added escape code handling.
+                            local fStart = cInd
+                            local fEnd = rawText:find("[^\\]%]", cInd + 1)
+                            if rawSub(cInd, cInd + 1) == "[[" then
+                                parseDefault("[[")
+                                cInd = cInd + 1
+                            elseif rawSub(cInd, cInd + 1) == "[]" then --this should never happen anymore
+                                newMode(curMode)
+                                languageCode = defaultKey
+                                cInd = cInd + 2
+                            elseif fStart ~= nil and fEnd ~= nil then
+                                local newCode = rawSub(fStart + 1, fEnd)
+
+                                if languageCode ~= newCode and curMode == "quote" then newMode(curMode) end
+                                languageCode = newCode:upper()
+                                cInd = rawText:find("%S", fEnd + 2) or #rawText --set index to the next non whitespace character after the code
+                            else
+                                parseDefault("[")
+                            end
+                        end,
+                        default = function(letter)
+                            charBuffer = charBuffer .. letter
+                            cInd = cInd + 1
+                        end,
+                    }
+
+                    local c
+
+                    --run this loop to generate textTable, then concatenate
+                    while cInd <= #rawText do
+                        c = rawSub(cInd, cInd)
+
+                        if mode_table[c] then
+                            mode_table[c]()
                         else
-                            randSource:init()
-
-                            local letterRoll = randSource:randInt(1, 100)
-                            if letterRoll > quality and char:match("[%p%s]") == nil then
-                                char = "-"
-                                rCount = rCount + 1
-                            end
-                            returnStr = returnStr .. char
-                            iCount = iCount + 1
+                            parseDefault(c)
                         end
                     end
-                    return returnStr
-                end
+                    newMode(curMode) --makes sure nothing is left out
 
-                local function wordBytes(word)
-                    local returnNum = 0
-                    if not type(word) == "string" then return 0 end
-                    for char in word:gmatch(".") do
-                        char = char:lower()
-                        returnNum = returnNum * 16
-                        if not math.tointeger(returnNum) then returnNum = math.tointeger(2 ^ 48) end
-                        returnNum = returnNum + math.abs(string.byte(char) - 100)
-                    end
-                    return returnNum
-                end
-
-                local function langWordRep(word, proficiency, byteLC)
-                    -- FezzedOne: The wordRoll parameter is now used.
-                    local vowels = {
-                        "a",
-                        "e",
-                        "i",
-                        "o",
-                        "u",
-                        "y",
-                    }
-                    local consonants = {
-                        "b",
-                        "c",
-                        "d",
-                        "f",
-                        "g",
-                        "h",
-                        "j",
-                        "k",
-                        "l",
-                        "m",
-                        "n",
-                        "p",
-                        "q",
-                        "r",
-                        "s",
-                        "t",
-                        "v",
-                        "w",
-                        "x",
-                        "z",
-                    }
-                    -- FezzedOne: Merge a list into a Lua pattern. Assumes input doesn't contain any characters that need to be escaped.
-                    local function mergePattern(list)
-                        local pattern = "["
-                        for _, char in ipairs(list) do
-                            pattern = pattern .. char
+                    local function trim(s)
+                        local l = 1
+                        while string.sub(s, l, l) == " " do
+                            l = l + 1
                         end
-                        return pattern .. "]"
-                    end
-
-                    local pickInd = 0
-                    local newWord = ""
-                    local wordLength = #word
-                    randSource:init(math.tointeger(byteLC + wordBytes(word)))
-                    for char in word:gmatch(".") do
-                        local charLower = char:lower()
-                        local isLower = char == charLower
-                        local vowelPattern = mergePattern(vowels)
-                        local compFail = randSource:randInt(0, 150)
-                            > (proficiency - (wordLength ^ 2 + 10) / (math.max(1, proficiency - 50) / 5))
-                        if proficiency < 5 or compFail then -- FezzedOne: Added a chance that a word will be partially comprehensible.
-                            if charLower:match(vowelPattern) then
-                                local randNum = randSource:randInt(1, #vowels)
-                                char = vowels[randNum]
-                            elseif not char:match("[%p]") then -- Don't mess with punctuation.
-                                local randNum = randSource:randInt(1, #consonants)
-                                char = consonants[randNum]
-                            end
+                        local r = #s
+                        while string.sub(s, r, r) == " " do
+                            r = r - 1
                         end
-                        if not isLower then char = char:upper() end
-                        newWord = newWord .. char
-                    end
-                    return newWord
-                end
-
-                local function langScramble(str, prof, langCode, msgColor, langColor)
-                    local returnStr = ""
-                    str = str .. " "
-                    str = str:gsub("  ", " ")
-                    local rCount = 0
-                    local words = 0
-                    for i in str:gmatch(".") do
-                        if i == " " then words = words + 1 end
-                    end
-                    words = words + 1
-                    local rMax = words - (words * (prof / 100))
-                    local wordBuffer = ""
-                    local byteLC = wordBytes(langCode)
-                    local iCount = 1
-                    local char
-                    local effProf = 64 * math.log(prof / 3 + 1, 10)
-                    local uniqueIdBytes = wordBytes(
-                        (xsb and isLocalPlayer(receiverEntityId)) and world.entityUniqueId(receiverEntityId)
-                            or player.uniqueId()
-                    )
-
-                    if langColor == nil then
-                        local hexDigits =
-                            { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F" }
-                        local randSource = sb.makeRandomSource()
-                        local hexMin = 1
-
-                        --not sure if there's an cleaner way to do this
-                        randSource:init(math.tointeger(byteLC + wordBytes("Red One")))
-                        local rNumR = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(math.tointeger(byteLC + wordBytes("Green Two")))
-                        local rNumG = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(math.tointeger(byteLC + wordBytes("Blue Three")))
-                        local rNumB = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(math.tointeger(byteLC + wordBytes("Red Four")))
-                        local rNumR2 = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(math.tointeger(byteLC + wordBytes("Green Five")))
-                        local rNumG2 = hexDigits[randSource:randInt(hexMin, 16)]
-                        randSource:init(math.tointeger(byteLC + wordBytes("Blue Six")))
-                        local rNumB2 = hexDigits[randSource:randInt(hexMin, 16)]
-                        langColor = "#" .. rNumR .. rNumG .. rNumB .. rNumR2 .. rNumG2 .. rNumB2
+                        return string.sub(s, l, r)
                     end
 
-                    while iCount <= #str do
-                        char = str:sub(iCount, iCount)
-                        -- FezzedOne: Got rid of hardcoded assumption that language keys are two characters long.
-                        if char == "[" and str:find(iCount, "]") ~= nil then
-                            local closingBracket = str:find("]", iCount)
-                            returnStr = returnStr .. char .. str:sub(iCount + 1, closingBracket)
-                            iCount = closingBracket + 1
-                        elseif char == " " and not wordBuffer:match("%a") and #wordBuffer > 0 then
-                            returnStr = returnStr .. " " .. wordBuffer
-                            wordBuffer = ""
-                        elseif char ~= "'" and char:match("[%s%p]") then
-                            if #wordBuffer > 0 then
-                                local wordLength = #wordBuffer
-                                local byteWord = wordBytes(wordBuffer)
-                                randSource:init(math.tointeger(uniqueIdBytes + byteLC + byteWord))
-                                local wordRoll = randSource:randInt(1, 100)
-                                if
-                                    effProf < 5
-                                    or (wordRoll + (wordLength ^ 2 / (math.max(1, effProf - 50) / 5)) - 10)
-                                        > effProf
-                                then
-                                    wordBuffer = langWordRep(trim(wordBuffer), effProf, byteLC)
-                                    wordBuffer = "^" .. langColor .. ";" .. wordBuffer .. "^" .. msgColor .. ";"
+                    local function degradeMessage(str, quality)
+                        local returnStr = ""
+                        local char
+                        local iCount = 1
+                        local rMax = (#str - 2) - ((#str - 2) * (quality / 100)) --basically, how many characters can be "-", helps
+                        local rCount = 0
+                        while iCount <= #str do
+                            char = str:sub(iCount, iCount)
+                            if char == "\\" then
+                                returnStr = returnStr .. str:sub(iCount + 1, iCount + 1)
+                                iCount = iCount + 2
+                            -- FezzedOne: Got rid of hardcoded assumption that language codes are two characters long.
+                            elseif char == "[" and str:find("]", iCount) ~= nil then
+                                local closingBracket = str:find("]", iCount)
+                                returnStr = returnStr .. str:sub(iCount, closingBracket)
+                                iCount = closingBracket + 1
+                            elseif char == "^" and str:find(";", iCount) ~= nil then
+                                local nextSemi = str:find(";", iCount)
+                                returnStr = returnStr .. str:sub(iCount, nextSemi)
+                                iCount = nextSemi + 1
+                            else
+                                randSource:init()
+
+                                local letterRoll = randSource:randInt(1, 100)
+                                if letterRoll > quality and char:match("[%p%s]") == nil then
+                                    char = "-"
                                     rCount = rCount + 1
                                 end
+                                returnStr = returnStr .. char
+                                iCount = iCount + 1
                             end
-                            returnStr = returnStr .. wordBuffer .. char
-                            wordBuffer = ""
-                        else
-                            wordBuffer = wordBuffer .. char
                         end
-                        iCount = iCount + 1
+                        return returnStr
                     end
 
-                    if returnStr:match("%s", #returnStr) then returnStr = returnStr:sub(0, #returnStr - 1) end
+                    local function wordBytes(word)
+                        local returnNum = 0
+                        if not type(word) == "string" then return 0 end
+                        for char in word:gmatch(".") do
+                            char = char:lower()
+                            returnNum = returnNum * 16
+                            if not math.tointeger(returnNum) then returnNum = math.tointeger(2 ^ 48) end
+                            returnNum = returnNum + math.abs(string.byte(char) - 100)
+                        end
+                        return returnNum
+                    end
 
-                    randSource:init()
-                    return returnStr
-                end
-
-                local colorTable = { --transparency is an options here, but it makes things hard to read
-                    [-4] = "#555",
-                    [-3] = "#777",
-                    [-2] = "#999",
-                    [-1] = "#bbb",
-                    [0] = "#ddd",
-                    [1] = "#fff",
-                    [2] = "#daa",
-                    [3] = "#d66",
-                    [4] = "#d00",
-                }
-
-                local function colorWithin(str, char, color, prevColor)
-                    local colorOn = false
-                    local charBuffer = ""
-                    for i in str:gmatch(".") do
-                        if i == char then
-                            if colorOn == false then
-                                charBuffer = charBuffer .. "^" .. color .. ";"
-                                colorOn = true
-                            else
-                                charBuffer = charBuffer .. "^" .. prevColor .. ";"
-                                colorOn = false
+                    local function langWordRep(word, proficiency, byteLC)
+                        -- FezzedOne: The wordRoll parameter is now used.
+                        local vowels = {
+                            "a",
+                            "e",
+                            "i",
+                            "o",
+                            "u",
+                            "y",
+                        }
+                        local consonants = {
+                            "b",
+                            "c",
+                            "d",
+                            "f",
+                            "g",
+                            "h",
+                            "j",
+                            "k",
+                            "l",
+                            "m",
+                            "n",
+                            "p",
+                            "q",
+                            "r",
+                            "s",
+                            "t",
+                            "v",
+                            "w",
+                            "x",
+                            "z",
+                        }
+                        -- FezzedOne: Merge a list into a Lua pattern. Assumes input doesn't contain any characters that need to be escaped.
+                        local function mergePattern(list)
+                            local pattern = "["
+                            for _, char in ipairs(list) do
+                                pattern = pattern .. char
                             end
-                        else
-                            --put this outside the if statement to make the characters appear as well as colors
-                            charBuffer = charBuffer .. i
+                            return pattern .. "]"
                         end
-                    end
-                    -- print("Charbuffer is " .. charBuffer)
-                    return charBuffer
-                end
 
-                local function cleanDoubleSpaces(str)
-                    --run a loop with the string, ignore codes (^whatever;), then remove more than one space in a row
-                    local cleanStr = ""
-                    local iCount = 1
-                    local prevChar = ""
-                    local prevColor = ""
-
-                    while iCount <= #str do
-                        local char = str:sub(iCount, iCount)
-                        local nextSemi = 0
-
-                        if char == "^" then
-                            nextSemi = str:find(";", iCount)
-
-                            if nextSemi ~= nil then
-                                local colorCode = str:sub(iCount, nextSemi)
-                                if colorCode ~= prevColor then cleanStr = cleanStr .. colorCode end
-                                prevColor = colorCode
-                                iCount = nextSemi
-                            end
-                        elseif char ~= " " or prevChar ~= " " then
-                            cleanStr = cleanStr .. char
-                            prevChar = char
-                        end
-                        iCount = iCount + 1
-                    end
-                    cleanStr = cleanStr:gsub("%{ ", "{")
-                    cleanStr = cleanStr:gsub(" %}", "}")
-                    return cleanStr
-                end
-
-                --do visual formatting here.
-                --for dialogue (NOT sounds), start degrading the quality of the message at 50% of the quotes's radius
-                local tableStr = ""
-                local prevStr = ""
-                local quoteCombo = ""
-                local soundCombo = ""
-                local prevType = "action"
-                local quoteOpen = false
-                local soundOpen = false
-                local hasValids = false
-                local chunkStr
-                local chunkType
-                local langBank = {} --populate with languages in inventory when you find them
-                local prevLang = getDefaultLang() --either the player's default language, or !!
-
-                if maxRad ~= -1 and (messageDistance > maxRad and validSum == 0) then
-                    message.text = ""
-                else
-                    chunkType = nil
-
-                    local prevChunk = ""
-                    local repeatFlag = false
-                    table.insert(textTable, {
-                        text = "",
-                        radius = "0",
-                        type = "bad",
-                        langKey = ":(",
-                        valid = false,
-                        msgQuality = 0,
-                    })
-
-                    for k, v in pairs(textTable) do
-                        if v["hasLOS"] == false and chunkType == "action" then v["valid"] = false end
-                        if v["valid"] then hasValids = true end
-                    end
-                    for k, v in pairs(textTable) do
-                        if v["radius"] == -1 or v["isRadio"] == true then v["valid"] = true end
-
-                        chunkStr = v["text"]
-                        chunkType = v["type"]
-                        local langKey = v["langKey"]
-                        if
-                            v["valid"] == true
-                            or (
-                                chunkType == "quote"
-                                and (
-                                    (k > 1 and textTable[k - 1]["type"] == "quote")
-                                    or (k < #textTable and textTable[k + 1]["type"] == "quote")
-                                )
-                            )
-                        then --check if this is surrounded by quotes
-                            v["valid"] = true --this should be set to true in here, since everything in this block should show up on the screen
-                            -- remember, noiserad is a const and radius is for the message
-
-                            local colorOverride = chunkStr:find("%^%#") ~= nil --don't touch colors if this is true
-                            local actionColor = "#fff" --white for non sound based chunks
-                            local msgColor = "#fff" --white for non sound based chunks
-                            --disguise unheard stuff
-                            if chunkType == "sound" then
-                                if not colorOverride then
-                                    msgColor = colorTable[volTable[v["radius"]]]
-                                    chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                        local pickInd = 0
+                        local newWord = ""
+                        local wordLength = #word
+                        randSource:init(math.tointeger(byteLC + wordBytes(word)))
+                        for char in word:gmatch(".") do
+                            local charLower = char:lower()
+                            local isLower = char == charLower
+                            local vowelPattern = mergePattern(vowels)
+                            local compFail = randSource:randInt(0, 150)
+                                > (proficiency - (wordLength ^ 2 + 10) / (math.max(1, proficiency - 50) / 5))
+                            if proficiency < 5 or compFail then -- FezzedOne: Added a chance that a word will be partially comprehensible.
+                                if charLower:match(vowelPattern) then
+                                    local randNum = randSource:randInt(1, #vowels)
+                                    char = vowels[randNum]
+                                elseif not char:match("[%p]") then -- Don't mess with punctuation.
+                                    local randNum = randSource:randInt(1, #consonants)
+                                    char = consonants[randNum]
                                 end
-                            elseif chunkType == "quote" then
-                                msgColor = colorTable[volTable[v["radius"]]]
+                            end
+                            if not isLower then char = char:upper() end
+                            newWord = newWord .. char
+                        end
+                        return newWord
+                    end
 
-                                if chunkType == "quote" and langKey ~= "!!" then
-                                    local langProf, langColor
-                                    if langBank[langKey] ~= nil then
-                                        langProf = langBank[langKey]["prof"]
-                                        langColor = langBank[langKey]["color"]
+                    local function langScramble(str, prof, langCode, msgColor, langColor)
+                        local returnStr = ""
+                        str = str .. " "
+                        str = str:gsub("  ", " ")
+                        local rCount = 0
+                        local words = 0
+                        for i in str:gmatch(".") do
+                            if i == " " then words = words + 1 end
+                        end
+                        words = words + 1
+                        local rMax = words - (words * (prof / 100))
+                        local wordBuffer = ""
+                        local byteLC = wordBytes(langCode)
+                        local iCount = 1
+                        local char
+                        local effProf = 64 * math.log(prof / 3 + 1, 10)
+                        local uniqueIdBytes = wordBytes(
+                            (xsb and isLocalPlayer(receiverEntityId)) and world.entityUniqueId(receiverEntityId)
+                                or player.uniqueId()
+                        )
+
+                        if langColor == nil then
+                            local hexDigits =
+                                { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F" }
+                            local randSource = sb.makeRandomSource()
+                            local hexMin = 1
+
+                            --not sure if there's an cleaner way to do this
+                            randSource:init(math.tointeger(byteLC + wordBytes("Red One")))
+                            local rNumR = hexDigits[randSource:randInt(hexMin, 16)]
+                            randSource:init(math.tointeger(byteLC + wordBytes("Green Two")))
+                            local rNumG = hexDigits[randSource:randInt(hexMin, 16)]
+                            randSource:init(math.tointeger(byteLC + wordBytes("Blue Three")))
+                            local rNumB = hexDigits[randSource:randInt(hexMin, 16)]
+                            randSource:init(math.tointeger(byteLC + wordBytes("Red Four")))
+                            local rNumR2 = hexDigits[randSource:randInt(hexMin, 16)]
+                            randSource:init(math.tointeger(byteLC + wordBytes("Green Five")))
+                            local rNumG2 = hexDigits[randSource:randInt(hexMin, 16)]
+                            randSource:init(math.tointeger(byteLC + wordBytes("Blue Six")))
+                            local rNumB2 = hexDigits[randSource:randInt(hexMin, 16)]
+                            langColor = "#" .. rNumR .. rNumG .. rNumB .. rNumR2 .. rNumG2 .. rNumB2
+                        end
+
+                        while iCount <= #str do
+                            char = str:sub(iCount, iCount)
+                            -- FezzedOne: Got rid of hardcoded assumption that language keys are two characters long.
+                            if char == "[" and str:find(iCount, "]") ~= nil then
+                                local closingBracket = str:find("]", iCount)
+                                returnStr = returnStr .. char .. str:sub(iCount + 1, closingBracket)
+                                iCount = closingBracket + 1
+                            elseif char == " " and not wordBuffer:match("%a") and #wordBuffer > 0 then
+                                returnStr = returnStr .. " " .. wordBuffer
+                                wordBuffer = ""
+                            elseif char ~= "'" and char:match("[%s%p]") then
+                                if #wordBuffer > 0 then
+                                    local wordLength = #wordBuffer
+                                    local byteWord = wordBytes(wordBuffer)
+                                    randSource:init(math.tointeger(uniqueIdBytes + byteLC + byteWord))
+                                    local wordRoll = randSource:randInt(1, 100)
+                                    if
+                                        effProf < 5
+                                        or (wordRoll + (wordLength ^ 2 / (math.max(1, effProf - 50) / 5)) - 10)
+                                            > effProf
+                                    then
+                                        wordBuffer = langWordRep(trim(wordBuffer), effProf, byteLC)
+                                        wordBuffer = "^" .. langColor .. ";" .. wordBuffer .. "^" .. msgColor .. ";"
+                                        rCount = rCount + 1
                                     end
-                                    if langProf == nil then
-                                        local receiverIsLocal = isLocalPlayer(receiverEntityId)
-                                        local newLang
-                                        if xsb and receiverIsLocal then
-                                            newLang = world
-                                                .sendEntityMessage(receiverEntityId, "hasLangKey", langKey)
-                                                :result() or nil
-                                        else
-                                            newLang = player.getItemWithParameter("langKey", langKey) or nil
-                                        end
-                                        if newLang then
-                                            langColor = newLang["parameters"]["color"]
-                                            local hasItem
-                                            if xsb and receiverIsLocal then
-                                                hasItem = world
-                                                    .sendEntityMessage(receiverEntityId, "langKeyCount", newLang)
-                                                    :result()
-                                            else
-                                                hasItem = player.hasCountOfItem(newLang, true)
-                                            end
+                                end
+                                returnStr = returnStr .. wordBuffer .. char
+                                wordBuffer = ""
+                            else
+                                wordBuffer = wordBuffer .. char
+                            end
+                            iCount = iCount + 1
+                        end
 
-                                            if hasItem then
-                                                langProf = hasItem * 10
+                        if returnStr:match("%s", #returnStr) then returnStr = returnStr:sub(0, #returnStr - 1) end
+
+                        randSource:init()
+                        return returnStr
+                    end
+
+                    local colorTable = { --transparency is an options here, but it makes things hard to read
+                        [-4] = "#555",
+                        [-3] = "#777",
+                        [-2] = "#999",
+                        [-1] = "#bbb",
+                        [0] = "#ddd",
+                        [1] = "#fff",
+                        [2] = "#daa",
+                        [3] = "#d66",
+                        [4] = "#d00",
+                    }
+
+                    local function colorWithin(str, char, color, prevColor)
+                        local colorOn = false
+                        local charBuffer = ""
+                        for i in str:gmatch(".") do
+                            if i == char then
+                                if colorOn == false then
+                                    charBuffer = charBuffer .. "^" .. color .. ";"
+                                    colorOn = true
+                                else
+                                    charBuffer = charBuffer .. "^" .. prevColor .. ";"
+                                    colorOn = false
+                                end
+                            else
+                                --put this outside the if statement to make the characters appear as well as colors
+                                charBuffer = charBuffer .. i
+                            end
+                        end
+                        -- print("Charbuffer is " .. charBuffer)
+                        return charBuffer
+                    end
+
+                    local function cleanDoubleSpaces(str)
+                        --run a loop with the string, ignore codes (^whatever;), then remove more than one space in a row
+                        local cleanStr = ""
+                        local iCount = 1
+                        local prevChar = ""
+                        local prevColor = ""
+
+                        while iCount <= #str do
+                            local char = str:sub(iCount, iCount)
+                            local nextSemi = 0
+
+                            if char == "^" then
+                                nextSemi = str:find(";", iCount)
+
+                                if nextSemi ~= nil then
+                                    local colorCode = str:sub(iCount, nextSemi)
+                                    if colorCode ~= prevColor then cleanStr = cleanStr .. colorCode end
+                                    prevColor = colorCode
+                                    iCount = nextSemi
+                                end
+                            elseif char ~= " " or prevChar ~= " " then
+                                cleanStr = cleanStr .. char
+                                prevChar = char
+                            end
+                            iCount = iCount + 1
+                        end
+                        cleanStr = cleanStr:gsub("%{ ", "{")
+                        cleanStr = cleanStr:gsub(" %}", "}")
+                        return cleanStr
+                    end
+
+                    --do visual formatting here.
+                    --for dialogue (NOT sounds), start degrading the quality of the message at 50% of the quotes's radius
+                    local tableStr = ""
+                    local prevStr = ""
+                    local quoteCombo = ""
+                    local soundCombo = ""
+                    local prevType = "action"
+                    local quoteOpen = false
+                    local soundOpen = false
+                    local hasValids = false
+                    local chunkStr
+                    local chunkType
+                    local langBank = {} --populate with languages in inventory when you find them
+                    local prevLang = getDefaultLang() --either the player's default language, or !!
+
+                    if maxRad ~= -1 and (messageDistance > maxRad and validSum == 0) then
+                        message.text = ""
+                    else
+                        chunkType = nil
+
+                        local prevChunk = ""
+                        local repeatFlag = false
+                        table.insert(textTable, {
+                            text = "",
+                            radius = "0",
+                            type = "bad",
+                            langKey = ":(",
+                            valid = false,
+                            msgQuality = 0,
+                        })
+
+                        for k, v in pairs(textTable) do
+                            if v["hasLOS"] == false and chunkType == "action" then v["valid"] = false end
+                            if v["valid"] then hasValids = true end
+                        end
+                        for k, v in pairs(textTable) do
+                            if v["radius"] == -1 or v["isRadio"] == true then v["valid"] = true end
+
+                            chunkStr = v["text"]
+                            chunkType = v["type"]
+                            local langKey = v["langKey"]
+                            if
+                                v["valid"] == true
+                                or (
+                                    chunkType == "quote"
+                                    and (
+                                        (k > 1 and textTable[k - 1]["type"] == "quote")
+                                        or (k < #textTable and textTable[k + 1]["type"] == "quote")
+                                    )
+                                )
+                            then --check if this is surrounded by quotes
+                                v["valid"] = true --this should be set to true in here, since everything in this block should show up on the screen
+                                -- remember, noiserad is a const and radius is for the message
+
+                                local colorOverride = chunkStr:find("%^%#") ~= nil --don't touch colors if this is true
+                                local actionColor = "#fff" --white for non sound based chunks
+                                local msgColor = "#fff" --white for non sound based chunks
+                                --disguise unheard stuff
+                                if chunkType == "sound" then
+                                    if not colorOverride then
+                                        msgColor = colorTable[volTable[v["radius"]]]
+                                        chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                    end
+                                elseif chunkType == "quote" then
+                                    msgColor = colorTable[volTable[v["radius"]]]
+
+                                    if chunkType == "quote" and langKey ~= "!!" then
+                                        local langProf, langColor
+                                        if langBank[langKey] ~= nil then
+                                            langProf = langBank[langKey]["prof"]
+                                            langColor = langBank[langKey]["color"]
+                                        end
+                                        if langProf == nil then
+                                            local receiverIsLocal = isLocalPlayer(receiverEntityId)
+                                            local newLang
+                                            if xsb and receiverIsLocal then
+                                                newLang = world
+                                                    .sendEntityMessage(receiverEntityId, "hasLangKey", langKey)
+                                                    :result() or nil
+                                            else
+                                                newLang = player.getItemWithParameter("langKey", langKey) or nil
+                                            end
+                                            if newLang then
+                                                langColor = newLang["parameters"]["color"]
+                                                local hasItem
+                                                if xsb and receiverIsLocal then
+                                                    hasItem = world
+                                                        .sendEntityMessage(receiverEntityId, "langKeyCount", newLang)
+                                                        :result()
+                                                else
+                                                    hasItem = player.hasCountOfItem(newLang, true)
+                                                end
+
+                                                if hasItem then
+                                                    langProf = hasItem * 10
+                                                else
+                                                    langProf = 0
+                                                end
+                                                langBank[langKey] = {
+                                                    prof = langProf,
+                                                    color = langColor,
+                                                }
                                             else
                                                 langProf = 0
                                             end
-                                            langBank[langKey] = {
-                                                prof = langProf,
-                                                color = langColor,
-                                            }
-                                        else
-                                            langProf = 0
+                                        end
+
+                                        if langProf < 100 then
+                                            --scramble the word
+                                            chunkStr =
+                                                langScramble(trim(chunkStr), langProf, langKey, msgColor, langColor)
                                         end
                                     end
+                                    --check message quality
+                                    if v["msgQuality"] < 100 and not v["isRadio"] and chunkType == "quote" then
+                                        chunkStr = degradeMessage(trim(chunkStr), v["msgQuality"])
+                                    end
 
-                                    if langProf < 100 then
-                                        --scramble the word
-                                        chunkStr = langScramble(trim(chunkStr), langProf, langKey, msgColor, langColor)
+                                    if not colorOverride then
+                                        chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                    end
+
+                                    --add in languagee indicator
+                                    if langKey ~= prevLang then
+                                        chunkStr = "^#fff;[" .. langKey .. "]^" .. msgColor .. "; " .. chunkStr
+                                        prevLang = langKey
                                     end
                                 end
-                                --check message quality
-                                if v["msgQuality"] < 100 and not v["isRadio"] and chunkType == "quote" then
-                                    chunkStr = degradeMessage(trim(chunkStr), v["msgQuality"])
-                                end
+                                chunkStr = chunkStr:gsub("%^%#fff%;%^%#fff;", "^#fff;")
+                                chunkStr = chunkStr:gsub("%^" .. msgColor .. ";%^#fff;", "^#fff;")
+                                chunkStr =
+                                    chunkStr:gsub("%^" .. msgColor .. ";%^" .. msgColor .. ";", "^" .. msgColor .. ";")
 
-                                if not colorOverride then
-                                    chunkStr = "^" .. msgColor .. ";" .. chunkStr .. "^" .. actionColor .. ";"
+                                --recolors certain things for emphasis
+                                if chunkType ~= "action" then --allow asterisks to stay in actions
+                                    chunkStr = colorWithin(chunkStr, "*", "#fe7", msgColor) --yellow
                                 end
-
-                                --add in languagee indicator
-                                if langKey ~= prevLang then
-                                    chunkStr = "^#fff;[" .. langKey .. "]^" .. msgColor .. "; " .. chunkStr
-                                    prevLang = langKey
-                                end
+                                -- FezzedOne: This now uses backticks.
+                                chunkStr = colorWithin(chunkStr, "`", "#d80", msgColor) --orange
+                            elseif chunkType == "quote" and hasValids and prevType ~= "quote" then
+                                chunkStr = "Says something."
+                                v["valid"] = true
+                                chunkType = "action"
                             end
-                            chunkStr = chunkStr:gsub("%^%#fff%;%^%#fff;", "^#fff;")
-                            chunkStr = chunkStr:gsub("%^" .. msgColor .. ";%^#fff;", "^#fff;")
-                            chunkStr =
-                                chunkStr:gsub("%^" .. msgColor .. ";%^" .. msgColor .. ";", "^" .. msgColor .. ";")
 
-                            --recolors certain things for emphasis
-                            if chunkType ~= "action" then --allow asterisks to stay in actions
-                                chunkStr = colorWithin(chunkStr, "*", "#fe7", msgColor) --yellow
+                            --after check, this puts formatted chunks in
+                            if chunkType ~= "quote" and prevType == "quote" then
+                                local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
+
+                                if not checkCombo:match("[%w%d]") then
+                                    if prevStr ~= "Says something." then
+                                        quoteCombo = "Says something."
+                                    else
+                                        quoteCombo = ""
+                                    end
+                                    prevStr = quoteCombo
+                                end
+
+                                quoteCombo = '"' .. quoteCombo .. '"'
+                                tableStr = tableStr .. " " .. quoteCombo
+                                quoteCombo = ""
                             end
-                            -- FezzedOne: This now uses backticks.
-                            chunkStr = colorWithin(chunkStr, "`", "#d80", msgColor) --orange
-                        elseif chunkType == "quote" and hasValids and prevType ~= "quote" then
-                            chunkStr = "Says something."
-                            v["valid"] = true
-                            chunkType = "action"
-                        end
+                            if chunkType ~= "sound" and prevType == "sound" then
+                                if soundCombo:match("[%w%d]") then
+                                    soundCombo = "<" .. soundCombo .. ">"
+                                    tableStr = tableStr .. " " .. soundCombo
+                                end
+                                soundCombo = ""
+                            end
 
-                        --after check, this puts formatted chunks in
-                        if chunkType ~= "quote" and prevType == "quote" then
-                            local checkCombo = quoteCombo:gsub("%[%w%w%]", "")
-
-                            if not checkCombo:match("[%w%d]") then
-                                if prevStr ~= "Says something." then
-                                    quoteCombo = "Says something."
+                            if v["valid"] and chunkType == "quote" then
+                                if quoteCombo:sub(#quoteCombo):match("%p") then
+                                    --this adds the space after a quote
+                                    quoteCombo = quoteCombo .. " " .. chunkStr
                                 else
-                                    quoteCombo = ""
+                                    quoteCombo = quoteCombo .. chunkStr
                                 end
-                                prevStr = quoteCombo
+                            elseif v["valid"] and chunkType == "sound" then
+                                if soundCombo:sub(#soundCombo):match("%p") then
+                                    --this adds the space after a quote
+                                    soundCombo = soundCombo .. " " .. chunkStr
+                                else
+                                    soundCombo = soundCombo .. chunkStr
+                                end
+                            elseif v["valid"] then --everything that isn't a sound or a quote goes here
+                                tableStr = tableStr .. " " .. chunkStr
+                                prevStr = chunkStr
                             end
 
-                            quoteCombo = '"' .. quoteCombo .. '"'
-                            tableStr = tableStr .. " " .. quoteCombo
-                            quoteCombo = ""
+                            prevType = chunkType
                         end
-                        if chunkType ~= "sound" and prevType == "sound" then
-                            if soundCombo:match("[%w%d]") then
-                                soundCombo = "<" .. soundCombo .. ">"
-                                tableStr = tableStr .. " " .. soundCombo
-                            end
-                            soundCombo = ""
-                        end
+                        tableStr = cleanDoubleSpaces(tableStr) --removes double spaces, ignores colors
+                        tableStr = tableStr:gsub(' "%s', ' "')
+                        tableStr = tableStr:gsub("}{", "...") --for multiple radios
+                        tableStr = trim(tableStr)
 
-                        if v["valid"] and chunkType == "quote" then
-                            if quoteCombo:sub(#quoteCombo):match("%p") then
-                                --this adds the space after a quote
-                                quoteCombo = quoteCombo .. " " .. chunkStr
-                            else
-                                quoteCombo = quoteCombo .. chunkStr
-                            end
-                        elseif v["valid"] and chunkType == "sound" then
-                            if soundCombo:sub(#soundCombo):match("%p") then
-                                --this adds the space after a quote
-                                soundCombo = soundCombo .. " " .. chunkStr
-                            else
-                                soundCombo = soundCombo .. chunkStr
-                            end
-                        elseif v["valid"] then --everything that isn't a sound or a quote goes here
-                            tableStr = tableStr .. " " .. chunkStr
-                            prevStr = chunkStr
-                        end
-
-                        prevType = chunkType
+                        message.text = tableStr
                     end
-                    tableStr = cleanDoubleSpaces(tableStr) --removes double spaces, ignores colors
-                    tableStr = tableStr:gsub(' "%s', ' "')
-                    tableStr = tableStr:gsub("}{", "...") --for multiple radios
-                    tableStr = trim(tableStr)
+                end
 
-                    message.text = tableStr
+                message.portrait = message.portrait and message.portrait ~= "" and message.portrait
+                    or message.connection
+                if copiedMessage then
+                    message.processed = true
+                    world.sendEntityMessage(receiverEntityId, "scc_add_message", message)
                 end
             end
-        end
 
-        message.portrait = message.portrait and message.portrait ~= "" and message.portrait or message.connection
+            if xsb and message.contentIsText then
+                for _, pId in ipairs(ownPlayers) do
+                    handleMessage(pId, deepCopy(message))
+                end
+                message.text = ""
+            elseif message.contentIsText then
+                handleMessage(receiverEntityId, deepCopy(message))
+                message.text = ""
+            else
+                handleMessage(receiverEntityId)
+            end
+        end
     end
 
     return message

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -447,7 +447,7 @@ function dynamicprox:onSendMessage(data)
                     end
                     globalMsg:sub(1, -2)
                     globalMsg = "{{" .. globalMsg .. "}}"
-                    globalMsg = globalMsg:gsub("[ ]*", " "):gsub("%{ ", "{"):gsub(" %}", "}")
+                    globalMsg = globalMsg:gsub("[ ]+", " "):gsub("%{ ", "{"):gsub(" %}", "}")
                     -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
                     chat.send(globalMsg, "Broadcast", false)
                 end
@@ -458,7 +458,7 @@ function dynamicprox:onSendMessage(data)
                     end
                     globalOocMsg:sub(1, -2)
                     globalOocMsg = "((" .. globalOocMsg .. "))"
-                    globalOocMsg = globalOocMsg:gsub("[ ]*", " ")
+                    globalOocMsg = globalOocMsg:gsub("[ ]+", " ")
                     -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.
                     chat.send(globalOocMsg, "Broadcast", false)
                 end

--- a/player.config.patch.lua
+++ b/player.config.patch.lua
@@ -1,0 +1,4 @@
+function patch(playerConfig)
+    if xsb then playerConfig.genericScriptContexts.sccDynamicChat = "/scripts/player_lang_proxy.lua" end
+    return playerConfig
+end

--- a/scripts/player_lang_proxy.lua
+++ b/scripts/player_lang_proxy.lua
@@ -1,0 +1,9 @@
+-- FezzedOne: This script is needed to correctly handle language items on secondary players. --
+function init()
+    message.setHandler("hasLangKey", function(_, isLocal, langKey)
+        if isLocal then return player.getItemWithParameter("langKey", langKey) end
+    end)
+    message.setHandler("langKeyCount", function(_, isLocal, langKeyItem)
+        if isLocal then return player.hasCountOfItem(langKeyItem, true) end
+    end)
+end


### PR DESCRIPTION
This PR adds the following changes:

- **[Bugfix]** Fixed a bug on xStarbound where dynamic chat after swapping to a secondary player — a player you previously weren't controlling, and in this case, one that you didn't originally connect with — wasn't correctly parsed. Note that xStarbound has a feature that allows a single client to control multiple players — i.e., multi-charactering on a single client. This PR sets Dynamic Proximity Chat up to correctly handle that feature.
- **[Bugfix]** Fixed another bug on xStarbound where dynamic chat always assumed that the current primary player — the one you're currently controlling — is the one whose position is to be used when determining whether chat is audible and actions are visible.
- **[Bugfix]** Fixed a `nil` dereference bug that froze the SCC interface whenever the dice rolling syntax was used. This bug was client-agnostic and had to do with SCC changing the way it handles timestamps.
- **[New]** If multiple players are loaded on an xStarbound client, dynamic proximity chat messages will be received from all loaded players' «perspectives». Message nicknames will be in `$senderNick -> $perspectiveNick` format if multiple players are loaded.
- **[New]** An extra check box has been added (on xStarbound only) so you can hide proximity chat from secondary players' perspectives — it will hide any chat from a secondary player's perspective *while that player is secondary*. So if you swap from loaded player A to loaded player B, any «player B's perspective» messages from *before* you swapped count as «secondary». This perspective handling even includes languages! (The check box isn't needed on OpenStarbound or StarExtensions clients because they don't support single-client multi-charactering.)
- **[New]** Added global OOC chat and global radio / action messages. Syntax is `((( OOC message )))` for global OOC (but the message will be shown with only double parentheses because of how SCC handles OOC chat colouring) and `{{ Radio/Action }}` or `<< Radio/Action >>` for global radio messages and actions (the message will show up with curly braces though). ~~Language tags aren't supported in global radio / action messages (because that would require a server-side message handler on an xStarbound or OpenStarbound server to function).~~
- **[Changed]** Item emphasis now uses backticks instead of backslashes (e.g., `\`text\``). This was done to allow backslash escapes.
- **[New]** Backslash escapes have been added. Almost every special character handled by the parser can be escaped this way. Escaping just the first bracket, brace or parenthesis of global OOC or radio/action messages «eats» the outer brackets, parentheses or braces though. To work around this, escape *all* of the left brackets, braces or parentheses.
- **[New]** Souped up the dice rolling system. In addition to the existing `|X|` syntax, the following syntax is accepted: `|XdY+N, XdY+N, ...|`, where commas separate consecutive rolls (e.g., `|3d6, 2d6, d20|`). X is the number of dice to roll and sum together in the roll, Y is the number of sides and N is a modifier. Addition (`+`), subtraction (`-`), multiplication (`*`) and floor division (`/`) are supported for modifiers; only one operation per roll is supported. The basic `|X|` syntax also supports comma-separated rolls now (e.g., `|20, 20, 20|` for 3 consecutive d20 rolls).
- **[New]** Removed the hardcoded two-character limit on language tags. Additionally, text in double brackets (e.g., `[[text]]`) is no longer parsed as a language tag.
- **[New]** Whitespace is now supported in language names passed to `/newlangitem`. Make sure to surround the language name with quotes!
- **[Bugfixes]** Fixed various bugs in the chat syntax parser for both incoming and outgoing messages, some of which caused SCC to «hang» and become unusable until disconnection.
- **[Change]** Adjusted the math behind language proficiencies to make language comprehension feel more sensible. If you have, say, 60% proficiency in a language, shorter words are more likely to be understood than longer ones now.
- **[Bugfix]** Fixed a bug where local radio messages incorrectly degraded over a distance as if they were just regular talking.
- **[New]** Added toggleable support for handling local chat messages as proximity chat (toggled with `/proxlocal`) and sending proximity chat messages in local chat (toggled with `/sendlocal`). This eases interoperability with existing roleplayers who don't have Dynamic Proximity Chat installed on their clients. Proximity messages sent with `/sendlocal` enabled always show up as Proximity messages for Dynamic Proximity Chat users even though they're sent in local chat, while *all* local messages are handled as if they were proximity messages if `/proxlocal` is enabled. (As a bonus, enabling `/sendlocal` extends local radio message range to the entire world!) Servers may require `/sendlocal` to be enabled on clients for server-side logging purposes.
- **[New]** Language tags now work on global action and radio messages sent in the Proximity tab! Default languages are also supported as you would expect.
- **[New]** Errors that occur while formatting or parsing proximity messages will no longer bring SCC down. They are now logged along with the offending message data.

By the way, Dynamic Proximity Chat actually coexists just fine alongside SCCRP's proximity chat if you have both installed. 

## Screenshots

From the «triple-clienting» client's view, with secondary messages enabled and disabled, respectively:

![image](https://github.com/user-attachments/assets/8566aee3-dfda-48e2-adfe-e8c550137979)
![image](https://github.com/user-attachments/assets/3e49c502-39e7-46f7-882b-4e314199e227)

From the other client's view:

![image](https://github.com/user-attachments/assets/12caeb17-f6f5-4ca9-8a6a-eab7ebd16fc5)

## And a fun fact

xStarbound also supports fully client-sided, networked clothing/vanity layering — inspired by a similar feature on that roleplay server which shall not be named. You may have noticed some layered clothing in the screenshots. Anyone with an xStarbound client can see layered clothing/vanity items on other players who also have xStarbound (although *technically*, xSB is only necessary on the viewer's «side» to see layered items).