### PR TITLE
Comms channels and bugfixes

### DIFF
--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
@@ -12,5 +12,9 @@
   "commands.sendlocal.desc": "Sets whether chat sent in the Dynamic tab will be sent as local chat. {on/off}",
   "commands.proxooc.desc": "Sets whether double-parentheses OOC chat - (( )) - received as Dynamic chat will be proximity-limited. {on/off}",
   "commands.dynamicsccrp.desc": "Sets whether SCCRP proximity messages will be handled as dynamic proximity chat",
-  "commands.timezone.desc": "Checks or sets the current timezone set for timestamps. {timezone, DST on/off}"
+  "commands.timezone.desc": "Checks or sets the current timezone set for timestamps. {timezone, DST on/off}",
+  "commands.commcode.desc": "Displays or sets your character's default comm code. {[new default]}",
+  "commands.commcodes.desc": "Displays all comm codes your character is listening on.",
+  "commands.addcommcode.desc": "Adds or modifies a comm code (or alias) your character is listening on. {comm code, [alias]}",
+  "commands.removecommcode.desc": "Removes a comm code your character is listening on. {comm code or alias}"
 }

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/en.json
@@ -12,7 +12,7 @@
   "commands.sendlocal.desc": "Sets whether chat sent in the Dynamic tab will be sent as local chat. {on/off}",
   "commands.proxooc.desc": "Sets whether double-parentheses OOC chat - (( )) - received as Dynamic chat will be proximity-limited. {on/off}",
   "commands.dynamicsccrp.desc": "Sets whether SCCRP proximity messages will be handled as dynamic proximity chat",
-  "commands.timezone.desc": "Checks or sets the current timezone set for timestamps. {timezone, DST on/off}",
+  "commands.timezone.desc": "Checks or sets the current timezone set for timestamps. {timezone or decimal hour offset, DST on/off}",
   "commands.commcode.desc": "Displays or sets your character's default comm code. {[new default]}",
   "commands.commcodes.desc": "Displays all comm codes your character is listening on.",
   "commands.addcommcode.desc": "Adds or modifies a comm code (or alias) your character is listening on. {comm code, [alias]}",

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
@@ -13,7 +13,7 @@
   "commands.sendlocal.desc": "Sets whether chat sent in the Dynamic tab will be sent as local chat. {on/off}",
   "commands.proxooc.desc": "Sets whether double-parentheses OOC chat - (( )) - received as Dynamic chat will be proximity-limited. {on/off}",
   "commands.dynamicsccrp.desc": "Sets whether SCCRP proximity messages will be handled as dynamic proximity chat",
-  "commands.timezone.desc": "Checks or sets the current timezone set for timestamps. {timezone, DST on/off}",
+  "commands.timezone.desc": "Checks or sets the current timezone set for timestamps. {timezone or decimal hour offset, DST on/off}",
   "commands.commcode.desc": "Displays or sets your character's default comm code. {[new default]}",
   "commands.commcodes.desc": "Displays all comm codes your character is listening on.",
   "commands.addcommcode.desc": "Adds or modifies a comm code (or alias) your character is listening on. {comm code, [alias]}",

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/locales/ru.json
@@ -12,5 +12,10 @@
   "commands.proxlocal.desc": "Sets whether received local chat will be handled as Dynamic chat. {on/off}",
   "commands.sendlocal.desc": "Sets whether chat sent in the Dynamic tab will be sent as local chat. {on/off}",
   "commands.proxooc.desc": "Sets whether double-parentheses OOC chat - (( )) - received as Dynamic chat will be proximity-limited. {on/off}",
-  "commands.dynamicsccrp.desc": "Sets whether SCCRP proximity messages will be handled as dynamic proximity chat"
+  "commands.dynamicsccrp.desc": "Sets whether SCCRP proximity messages will be handled as dynamic proximity chat",
+  "commands.timezone.desc": "Checks or sets the current timezone set for timestamps. {timezone, DST on/off}",
+  "commands.commcode.desc": "Displays or sets your character's default comm code. {[new default]}",
+  "commands.commcodes.desc": "Displays all comm codes your character is listening on.",
+  "commands.addcommcode.desc": "Adds or modifies a comm code (or alias) your character is listening on. {comm code, [alias]}",
+  "commands.removecommcode.desc": "Removes a comm code your character is listening on. {comm code or alias}"
 }

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -321,9 +321,16 @@ function dynamicprox:registerMessageHandlers(shared) --look at this function in 
             if curZone > 0 then zoneStr = "+" .. zoneStr end
             return "Current time offset is ^#fe7;" .. zoneStr .. "^reset;"
         elseif tzTable[zoneStr:upper()] == nil then
-            return 'Timezone "^#fe7;'
-                .. zoneStr
-                .. "^reset;\" doesn't exist or isn't supported. Try using a timezone abbreviation (UTC, CET, EST, CST, MST, PST, etc)"
+            local tzOffset = tonumber(zoneStr)
+            if tzOffset then
+                local offsetStr = string.format("%.0f:%.2d", math.floor(tzOffset), (tzOffset % 1 * 60))
+                root.setConfiguration("DynamicProxChat::timeZone", tzOffset)
+                return "Timezone offset set to ^#fe7;" .. offsetStr .. "^reset;"
+            else
+                return 'Timezone "^#fe7;'
+                    .. zoneStr
+                    .. "^reset;\" doesn't exist or isn't supported. Try using a timezone abbreviation (UTC, CET, EST, CST, MST, PST, etc.) or manually specifying an offset in decimal hours."
+            end
         else
             zoneStr = zoneStr:upper()
             local newTime = tzTable[zoneStr] or 0

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -2151,7 +2151,6 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                         message.portrait = message.portrait and message.portrait ~= "" and message.portrait
                             or message.connection
                     else -- FezzedOne: Remove the portrait from the message if the receiver can't see the sender.
-                        if not message.inEarShot then message.nickname = "???" end
                         -- Use a dummy negative connection ID so that a portrait is never "grabbed" by SCC.
                         message.connection = -message.connection
                         message.portrait = message.connection

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -800,7 +800,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                 -- so look for the first rendered player belonging to the author's client. Kinda kludgy, but this is what we have to do for xStarbound clients
                 -- that don't send the required information because they don't have this mod or SCCRP!
                 if not (authorRendered or hasAuthorPrefix or message.sourceId) then
-                    for i = (message.connection * -65536 + 1), (message.connection * -65536 + 255), 1 do
+                    for i = (message.connection * -65536 + 1), (message.connection * -65536 + 65535), 1 do
                         if world.entityExists(i) and world.entityType(i) == "player" then
                             authorEntityId = i
                             authorRendered = true

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -829,7 +829,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                     if xsb and not message.isSccrp then -- FezzedOne: Already handled in SCCRP with my PR.
                         if copiedMessage or message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
                             if world.entityExists(receiverEntityId) then
-                                local receiverName = world.entityName(receiverEntityId)
+                                local receiverName = world.entityName(receiverEntityId) or "<n/a>"
                                 if #ownPlayers ~= 1 then
                                     message.nickname = message.nickname .. " -> " .. receiverName
                                 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -833,6 +833,7 @@ function dynamicprox:onSendMessage(data)
                     end
                     iCount = iCount + 1
                 end
+                local commKey = ""
                 if rawText:find("{.*}") then
                     local defaultCommCode = world.sendEntityMessage(player.id(), "getDefaultCommCode"):result()
                     if defaultCommCode == nil then
@@ -840,8 +841,8 @@ function dynamicprox:onSendMessage(data)
                     elseif defaultCommCode == false then
                         defaultCommCode = "-"
                     end
-                    if defaultCommCode ~= "0" then defaultCommCode = "[" .. defaultCommCode .. "] " end
-                    rawText = defaultCommCode .. rawText
+                    commKey = defaultCommCode ~= "0" and ("[" .. defaultCommCode .. "] ") or ""
+                    rawText = commKey .. rawText
                 end
                 data.content = rawText
                 data.text = ""
@@ -884,7 +885,7 @@ function dynamicprox:onSendMessage(data)
                         globalMsg = globalMsg .. str .. " "
                     end
                     globalMsg:sub(1, -2)
-                    globalMsg = "{{" .. globalMsg .. "}}"
+                    globalMsg = commKey .. "{{" .. globalMsg .. "}}"
                     globalMsg = globalMsg:gsub("[ ]+", " "):gsub("%{ ", "{"):gsub(" %}", "}")
                     globalMsg = DynamicProxPrefix .. chatTags .. globalMsg
                     -- The third parameter is ignored on StarExtensions, but retains the "..." chat bubble on xStarbound and OpenStarbound.

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -840,7 +840,7 @@ function dynamicprox:onSendMessage(data)
                     elseif defaultCommCode == false then
                         defaultCommCode = "-"
                     end
-                    defaultCommCode = "[" .. defaultCommCode .. "] "
+                    if defaultCommCode ~= "0" then defaultCommCode = "[" .. defaultCommCode .. "] " end
                     rawText = defaultCommCode .. rawText
                 end
                 data.content = rawText

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -827,9 +827,13 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                     local message = copiedMessage or message
                     if xsb then
                         if copiedMessage or message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
-                            local receiverName = world.entityName(receiverEntityId)
-                            if #ownPlayers ~= 1 then message.nickname = message.nickname .. " -> " .. receiverName end
-                            if receiverEntityId ~= player.id() then message.mode = "ProxSecondary" end
+                            if world.entityExists(receiverEntityId) then
+                                local receiverName = world.entityName(receiverEntityId)
+                                if #ownPlayers ~= 1 then
+                                    message.nickname = message.nickname .. " -> " .. receiverName
+                                end
+                                if receiverEntityId ~= player.id() then message.mode = "ProxSecondary" end
+                            end
                         end
                     end
                     do

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -626,22 +626,6 @@ function dynamicprox:onSendMessage(data)
                     boundMode = "position",
                 })
 
-                -- if xsb then -- FezzedOne: On xStarbound, filter out local secondaries to avoid showing duplicate sent messages.
-                --     local localPlayers = world.ownPlayers()
-                --     local primaryPlayer = world.primaryPlayer()
-                --     for i = #localPlayers, 1, -1 do
-                --         if localPlayers[i] == primaryPlayer then
-                --             table.remove(localPlayers, i)
-                --             break
-                --         end
-                --     end
-                --     for i = #players, 1, -1 do
-                --         for j = 1, #localPlayers, 1 do
-                --             if players[i] == localPlayers[j] then table.remove(players, i) end
-                --         end
-                --     end
-                -- end
-
                 -- FezzedOne: Added a setting that allows proximity chat to be sent as local chat for compatibility with «standard» local chat.
                 -- Chat sent this way is prefixed so that it always shows up as proximity chat for those with the mod installed.
                 local chatTags = AuthorIdPrefix
@@ -729,7 +713,11 @@ function dynamicprox:formatIncomingMessage(rawMessage)
         local isSccrpMessage = message.mode == "Proximity" and not message.targetId
         local showAsProximity = (sccrpInstalled() and isSccrpMessage)
         local showAsLocal = message.mode == "Local"
-        if not root.getConfiguration("DynamicProxChat::handleSccrpProx") then skipHandling = showAsProximity end
+        -- Fezzedone: Whoops. Forgot to actually handle (or rather, not handle) SCCRP announcement messages.
+        if message.text:sub(1, #AnnouncementPrefix) == AnnouncementPrefix then skipHandling = true end
+        if not root.getConfiguration("DynamicProxChat::handleSccrpProx") then
+            skipHandling = skipHandling or showAsProximity
+        end
 
         -- FezzedOne: This setting allows local chat to be «funneled» into proximity chat and appropriately formatted and filtered automatically.
         if

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -745,6 +745,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
         end
         if message.mode == "Proximity" and not skipHandling and not message.processed then
             message.isSccrp = isSccrpMessage or nil
+            message.contentIsText = isSccrpMessage or message.contentIsText
             -- FezzedOne: These are from my SCCRP PR. Ensures that SCCRP messages from and to xStarbound clients are always correctly handled.
             if message.isSccrp then
                 message.sourceId = message.senderId
@@ -825,7 +826,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                     local uncapRad = isGlobalChat
                     local wasGlobal = isGlobalChat
                     local message = copiedMessage or message
-                    if xsb then
+                    if xsb and not message.isSccrp then -- FezzedOne: Already handled in SCCRP with my PR.
                         if copiedMessage or message.targetId then -- FezzedOne: Show the receiver's name for disambiguation on xClient.
                             if world.entityExists(receiverEntityId) then
                                 local receiverName = world.entityName(receiverEntityId)

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -811,6 +811,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                 local receiverEntityId = message.targetId or player.id()
                 -- FezzedOne: DPC-side part of fix for SCCRP portraits in dynamically handled messages.
                 message.senderId = authorEntityId
+                message.sourceId = authorEntityId
                 message.receiverId = receiverEntityId
                 local ownPlayers = {}
                 if xsb then ownPlayers = world.ownPlayers() end
@@ -1875,7 +1876,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
 end
 
 function dynamicprox:onReceiveMessage(message) --here for logging the message you receive, just in case you wanted to save it or something
-    if message.connection ~= 0 and (message.mode == "Prox" or message.mode == "ProxSecondary") then
+    if message.connection ~= 0 and (message.sourceId or message.mode == "Prox" or message.mode == "ProxSecondary") then
         sb.logInfo("Chat: <%s> %s", message.nickname:gsub("%^[^^;]-;", ""), message.text:gsub("%^[^^;]-;", ""))
     end
 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1080,6 +1080,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
 
                         -- FezzedOne: This will be used to determine whether to hide the nick and portrait.
                         message.inSight = inSight
+                        message.inEarShot = false
 
                         -- FezzedOne: Get the player's comm codes for later.
                         local playerCommCodes = world.sendEntityMessage(receiverEntityId, "getCommCodes"):result()
@@ -1923,6 +1924,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
 
                                 chunkStr = v["text"]
                                 chunkType = v["type"]
+                                if chunkType == "quote" and v["valid"] then message.inEarShot = true end
                                 local langKey = v["langKey"]
                                 if
                                     v["valid"] == true
@@ -2149,7 +2151,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                         message.portrait = message.portrait and message.portrait ~= "" and message.portrait
                             or message.connection
                     else -- FezzedOne: Remove the portrait from the message if the receiver can't see the sender.
-                        message.nickname = "???"
+                        if not message.inEarShot then message.nickname = "???" end
                         -- Use a dummy negative connection ID so that a portrait is never "grabbed" by SCC.
                         message.connection = -message.connection
                         message.portrait = message.connection

--- a/scripts/player_lang_proxy.lua
+++ b/scripts/player_lang_proxy.lua
@@ -6,4 +6,26 @@ function init()
     message.setHandler("langKeyCount", function(_, isLocal, langKeyItem)
         if isLocal then return player.hasCountOfItem(langKeyItem, true) end
     end)
+    message.setHandler("getCommCodes", function(_, isLocal)
+        if isLocal then return player.getProperty("DynProxChat::commCodes") or { ["0"] = false } end
+    end)
+    message.setHandler("setCommCodes", function(_, isLocal, newCommCodes)
+        if isLocal then return player.setProperty("DynProxChat::commCodes", newCommCodes or { ["0"] = false }) end
+    end)
+    message.setHandler("getDefaultCommCode", function(_, isLocal, newDefault)
+        if isLocal then
+            local default = player.getProperty("DynProxChat::defaultCommCode")
+            if default ~= nil then
+                return default
+            else
+                return "0"
+            end
+        end
+    end)
+    message.setHandler("setDefaultCommCode", function(_, isLocal, newDefault)
+        if isLocal then
+            if newDefault == nil then newDefault = "0" end
+            return player.setProperty("DynProxChat::defaultCommCode", newDefault)
+        end
+    end)
 end


### PR DESCRIPTION
This PR adds the following bugfixes and changes:

- **[Change]** Removed the workaround in Dynamic Proximity Chat for SCC's sometimes incorrect connection ID calculations for players controlled by xStarbound clients, since I've PRed a fix for that to SCC and SCCRP.
- **[Change]** Added a fail-safe for receiver tags in DPC messages just in case a receiver no longer exists.
- **[Bugfix]** Fixed an error thrown when DPC formats SCCRP proximity messages.
- **[Change]** When it isn't sure of a sender's entity ID, DPC now scans the _entire_ entity space for the sender's connection ID, as this won't even cause so much as a noticeable frame spike. Yes, I actually did a performance test for this.
- **[Bugfix]** *Actually* skipped handling SCCRP announcement messages this time. Whoops.
- **[New]** Portraits are now hidden if you can't see a character (in line of sight).
- **[NEW]** Added comms channels! You only sees comms on the channels you're listening in on. To send a message on a given comms channel, use `[N]`, where `N` is an integer comm code or an alphanumeric alias, before your roleplay message, the same way you'd specify a language code. You may only send messages on channels you are listening in on, so ask ICly for comm codes! Characters start out listening on (and sending in) comm code `0` by default. Also added four new commands:
  - *`/commcodes`:* Lists all comm codes your character is listening in on. Comm codes are saved on a per-character basis. (*And* handled appropriately on xStarbound if you have multiple characters loaded!)
  - *`/commcode [$newDefault]`:* Shows you your default commcode for sending messages without a comm code specifier, or if specified, sets your default. Setting your default to `-` means you must always explicitly specify a commcode in order for roleplay in comms brackets to show up as comms. You may specify your default commcode by its alias.
  - *`/addcommcode $newCommCode [$alias]`:* Adds or modifies a listened comm code, optionally adding, modifying or (if left unspecified) removing an alphanumeric alias. Aliases are handled before language code checks — i.e., if `[ABC]` is an alias, it won't be parsed as a language code when you send messages.
  - *`/removecommcode $commCodeOrAlias`:* Removes a listened comm code. You may specify the code to remove by its alias, if any.
- **[New]** `/timezone` can now also take decimal hour offsets in addition to timezone identifiers.