### PR TITLE
Fixed escaping of backslashes, asterisks and backticks.

### DIFF
--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1457,9 +1457,12 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                             end,
                             ["/"] = function() parseDefault("/") end,
                             ["`"] = function() parseDefault("`") end,
-                            ["\\"] = function() -- Allow escaping any specially parsed character with `\`.
+                            ["\\"] = function() -- Allow escaping any specially parsed character with `\`. Also allow escaping `\` itself.
                                 local nextChar = rawSub(cInd + 1, cInd + 1)
-                                parseDefault(nextChar)
+                                -- Since backtick and asterisk parsing are handled later, keep the escaping backslash for these special cases.
+                                if nextChar == "*" or nextChar == "`" then charBuffer = charBuffer .. "\\" end
+                                local prevChar = cInd ~= 1 and rawSub(cInd - 1, cInd - 1) or ""
+                                if prevChar ~= "\\" then parseDefault(nextChar) end
                                 cInd = cInd + 1
                             end,
                             ["("] = function() --check for number of parentheses
@@ -1812,23 +1815,38 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                         }
 
                         local function colorWithin(str, char, color, prevColor)
+                            -- FezzedOne: Annoying that this function also has to handle escape syntax properly.
+                            sb.logInfo(DEBUG_PREFIX .. "Colouring chunk '" .. tostring(str) .. "'")
                             local colorOn = false
+                            local escaped = false
                             local charBuffer = ""
                             for i in str:gmatch(".") do
-                                if i == char then
-                                    if colorOn == false then
-                                        charBuffer = charBuffer .. "^" .. color .. ";"
-                                        colorOn = true
+                                if i == "\\" then
+                                    if escaped then -- Have to handle printing escaped backslashes a *second* time.
+                                        escaped = false
+                                        charBuffer = charBuffer .. i
                                     else
-                                        charBuffer = charBuffer .. "^" .. prevColor .. ";"
-                                        colorOn = false
+                                        escaped = true
+                                    end
+                                elseif i == char then
+                                    if escaped then
+                                        escaped = false
+                                        charBuffer = charBuffer .. i
+                                    else
+                                        if colorOn == false then
+                                            charBuffer = charBuffer .. "^" .. color .. ";"
+                                            colorOn = true
+                                        else
+                                            charBuffer = charBuffer .. "^" .. prevColor .. ";"
+                                            colorOn = false
+                                        end
                                     end
                                 else
-                                    --put this outside the if statement to make the characters appear as well as colors
+                                    escaped = false
                                     charBuffer = charBuffer .. i
                                 end
                             end
-                            -- print("Charbuffer is " .. charBuffer)
+                            sb.logInfo(DEBUG_PREFIX .. "Char buffer: '" .. charBuffer .. "'")
                             return charBuffer
                         end
 
@@ -2039,11 +2057,19 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                                     )
 
                                     --recolors certain things for emphasis
-                                    if chunkType ~= "action" then --allow asterisks to stay in actions
+                                    -- Remove emphasis colouring from OOC chunks.
+                                    if
+                                        chunkType ~= "action"
+                                        and chunkType ~= "gOOC"
+                                        and chunkType ~= "lOOC"
+                                        and chunkType ~= "pOOC"
+                                    then --allow asterisks to stay in actions
                                         chunkStr = colorWithin(chunkStr, "*", "#fe7", msgColor) --yellow
                                     end
-                                    -- FezzedOne: This now uses backticks.
-                                    chunkStr = colorWithin(chunkStr, "`", "#d80", msgColor) --orange
+                                    -- FezzedOne: This now uses backticks. Also removed emphasis colouring from OOC chunks.
+                                    if chunkType ~= "gOOC" and chunkType ~= "lOOC" and chunkType ~= "pOOC" then
+                                        chunkStr = colorWithin(chunkStr, "`", "#d80", msgColor) --orange
+                                    end
                                 elseif chunkType == "quote" and hasValids and prevType ~= "quote" then
                                     chunkStr = "Says something."
                                     v["valid"] = true

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1842,6 +1842,8 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                                         end
                                     end
                                 else
+                                    -- Don't eat backslashes unnecessarily.
+                                    if escaped then charBuffer = charBuffer .. "\\" end
                                     escaped = false
                                     charBuffer = charBuffer .. i
                                 end

--- a/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
+++ b/interface/scripted/starcustomchat/plugins/dynamicprox/proximity.lua
@@ -1816,7 +1816,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
 
                         local function colorWithin(str, char, color, prevColor)
                             -- FezzedOne: Annoying that this function also has to handle escape syntax properly.
-                            sb.logInfo(DEBUG_PREFIX .. "Colouring chunk '" .. tostring(str) .. "'")
+                            -- sb.logInfo(DEBUG_PREFIX .. "Colouring chunk '" .. tostring(str) .. "'")
                             local colorOn = false
                             local escaped = false
                             local charBuffer = ""
@@ -1846,7 +1846,7 @@ function dynamicprox:formatIncomingMessage(rawMessage)
                                     charBuffer = charBuffer .. i
                                 end
                             end
-                            sb.logInfo(DEBUG_PREFIX .. "Char buffer: '" .. charBuffer .. "'")
+                            -- sb.logInfo(DEBUG_PREFIX .. "Char buffer: '" .. charBuffer .. "'")
                             return charBuffer
                         end
 

--- a/player.config.patch.lua
+++ b/player.config.patch.lua
@@ -1,4 +1,4 @@
 function patch(playerConfig)
-    if xsb then playerConfig.genericScriptContexts.sccDynamicChat = "/scripts/player_lang_proxy.lua" end
+    playerConfig.genericScriptContexts.sccDynamicChat = "/scripts/player_lang_proxy.lua"
     return playerConfig
 end


### PR DESCRIPTION
This PR adds the following changes:

- **[Bugfix]** Backslashes (`\`), asterisks (`*`) and backticks (`` ` ``) can now be properly escaped (e.g., `\\`, `\*`, `` \` ``) in messages instead of the escapes getting «eaten» by the code for emphasis colouring. (There's a minor issue where `\\*` and `` \\` `` get parsed as `\*` and `` \` ``, but this can't be fixed without moving the code that parses emphasis markers to the main parsing code to avoid a double pass.)
- **[Change]** Emphasis colouring (and therefore the second pass for asterisk and backtick parsing) no longer happens in OOC parts of messages, because people commonly use asterisks as a correction marker in OOC, among other things. (This does mean that `\*` and `` \` `` are printed verbatim when in OOC, with the backslash, but I consider this okay because you don't need to escape these characters in OOC anyway.)
- **[Bugfix]** Saved commcodes now work on OpenStarbound. Whoops. (No StarExtensions support though.)